### PR TITLE
Fixing TakeOver strategy description: it does not take over, if there…

### DIFF
--- a/Ch05/Ch05.md
+++ b/Ch05/Ch05.md
@@ -58,8 +58,8 @@ and inspect things. The point is that RavenDB will send those details to your co
 start handling batches of documents. 
 
 ```{caption="Opening and using a subscription to process customers" .cs}
-var options = new SubscriptionConnectionOptions("CustomersSubscription");
-using(var subscription = store.Subscriptions.Open<Customer>(options)))
+var options = new SubscriptionWorkerOptions("CustomersSubscription");
+using(var subscription = store.Subscriptions.GetSubscriptionWorker<Customer>(options)))
 {
 	// wait until the subscription is done
 	// typically, a subscription lasts for a very long time
@@ -678,7 +678,7 @@ to the client-side types.
 ### Error handling and recovery with subscriptions
 
 What happens when there's an error in the processing of a document? Imagine that we had code inside the lambda in the `Run` method and that code threw an 
-exception. Unless you set `SubscriptionConnectionOptions.IgnoreSubscriberErrors`,^[And you probably shouldn't do that.] we'll abort processing of the 
+exception. Unless you set `SubscriptionWorkerOptions.IgnoreSubscriberErrors`,^[And you probably shouldn't do that.] we'll abort processing of the 
 subscription and the `Run` will raise an error. Typical handling in that scenario is to dispose of the subscription and immediately open it again. 
 
 Assuming the error is transient, we'll start processing from the last batch we received and continue forward from there. If the error isn't transient&mdash;for example,
@@ -704,8 +704,8 @@ things going on in this listing, so take the time to carefully read through the 
 var errorTimings = new Queue<DateTime>();
 while(true)
 {
-	var options = new SubscriptionConnectionOptions(subscriptionName);
-	var subscription = store.Subscriptions.Open<SupportCall>(
+	var options = new SubscriptionWorkerOptions(subscriptionName);
+	var subscription = store.Subscriptions.GetSubscriptionWorker<SupportCall>(
 		options));
 
 	try
@@ -805,9 +805,9 @@ In batch mode, the subscriptions are run on a schedule. When they run out of wor
 Listing 5.15 shows how you can write a self-stopping subscription.
 
 ```{caption="Stop the subscription after 15 minutes of inactivity" .cs}
-var options = new SubscriptionConnectionOptions(subscriptionName);
+var options = new SubscriptionWorkerOptions(subscriptionName);
 using(var subscription = store
-		.Subscriptions.Open<SupportCall>(options)))
+		.Subscriptions.GetSubscriptionWorker<SupportCall>(options)))
 {
 	var waitForWork = new ManualResetEvent(false);
 	var task = subscription.Run(batch =>
@@ -839,7 +839,7 @@ the issue that we'll also have higher resource usage because we need to process 
 
 Luckily, RavenDB subscriptions don't work like that. Instead, a subscription is always opened by one and only one client. By default, if two clients 
 attempt to open the same subscription, one of them will succeed and the other one will raise an error because it couldn't take hold of the subscription.
-This is controlled by the `SubscriptionOpeningStrategy` option set on the `SubscriptionConnectionOptions.Strategy`. The various options of this property are
+This is controlled by the `SubscriptionOpeningStrategy` option set on the `SubscriptionWorkerOptions.Strategy`. The various options of this property are
 
 * `OpenIfFree`&mdash;the default. The client will attempt to open the subscription but will fail if another client is already holding it. This is suitable in cases where you're running subscriptions in batch/schedule mode. If another client is already processing it, there's no need to process anything yourself. 
 
@@ -882,7 +882,7 @@ actually doing this is shown in Listing 5.16.
 
 ```{caption="Delete the emails to send after successful send" .cs}
 using (var subscription = 
-	store.Subscriptions.Open<EmailToSend>(options))
+	store.Subscriptions.GetSubscriptionWorker<EmailToSend>(options))
 {
     await subscription.Run(async batch =>
     {
@@ -963,8 +963,8 @@ store.Subscriptions.Create<Revision<Customer>>(
 );
 
 using(var subscription = 
-	store.Subscriptions.Open<Revision<Customer>>(
-		new SubscriptionConnectionOptions(subscriptionName)
+	store.Subscriptions.GetSubscriptionWorker<Revision<Customer>>(
+		new SubscriptionWorkerOptions(subscriptionName)
 	)))
 {
 
@@ -1110,7 +1110,7 @@ store = document_store (
 	)
 store.initialize()
 
-with store.subscriptions.open(
+with store.Subscriptions.GetSubscriptionWorker(
 	subscription_connection_options(
 		id = "new-customers-welcome-email"
 	)) as subscription:

--- a/Ch05/Ch05.md
+++ b/Ch05/Ch05.md
@@ -843,7 +843,7 @@ This is controlled by the `SubscriptionOpeningStrategy` option set on the `Subsc
 
 * `OpenIfFree`&mdash;the default. The client will attempt to open the subscription but will fail if another client is already holding it. This is suitable in cases where you're running subscriptions in batch/schedule mode. If another client is already processing it, there's no need to process anything yourself. 
 
-* `TakeOver`&mdash;the client will attempt to open the subscription even if a client is already connected to it. If there's a connected client, its connection will be closed. This is used to force the subscription open operation to succeed for a particular client. It's recommend to only enable this with an eye toward the global behavior across all your clients and subscriptions since two clients that attempt to connect with this mode will kick one another off the subscription as they each try to hold it.
+* `TakeOver`&mdash;the client will attempt to open the subscription even if a client is already connected to it. If there's a connected client, its connection will be closed. This is used to force the subscription open operation to succeed for a particular client. If an incoming subscription try to take over an existing one, which also has a "take over" strategy, the incoming subscription will "loose" the contest.
 
 * `WaitForFree`&mdash;the client will attempt to open the subscription, but if there's already a connected client, it will keep trying to acquire the connection. This is suitable for high availability mode, when you have multiple clients attempting to acquire the same subscription and you want one of them to succeed while the rest stand ready in case that one fails.
 


### PR DESCRIPTION
… is already a take over subscription exists
Also, added fix to API changes: Subscription => SubscriptionWorker