### PR TITLE
Fix the link to Amazon KindleGen

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ To create the build, run .\build.ps1 and then look in the Output directory.
 
 Create *.mobi file for Amazon Kindle 
 =============
-1. Download [Amazon's KindleGen](http://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000234621) and extract it to C:\tools\kindlegen (or modify the release build)
+1. Download [Amazon's KindleGen](https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211) and extract it to C:\tools\kindlegen (or modify the release build)
 2. Execute c:\tools\kindlegen\kindlegen.exe .\Output\Inside RavenDB 4.0.epub
 


### PR DESCRIPTION
The current link to Amazon KindleGen is broken.