### PR TITLE
Change footnote syntax

### DIFF
--- a/Ch02/Ch02.md
+++ b/Ch02/Ch02.md
@@ -116,9 +116,7 @@ your browser. For simplicity's sake, I'm going to assume from now on that you're
 on port 8080. Point your browser to [http://localhost:8080](http://localhost:8080), and you should be greeted with
 an empty RavenDB instance. You can see how it looks in Figure 2.1.
 
-^^^ Figure 2.1. *Empty RavenDB node*
 ![Empty RavenDB node](./Ch02/img01.png)
-^^^
 
 What we have right now is a RavenDB node that is a self-contained cluster.[^1] 
 Now that we have a running node, the next step is to create a new database on this node. 

--- a/Ch02/Ch02.md
+++ b/Ch02/Ch02.md
@@ -116,7 +116,9 @@ your browser. For simplicity's sake, I'm going to assume from now on that you're
 on port 8080. Point your browser to [http://localhost:8080](http://localhost:8080), and you should be greeted with
 an empty RavenDB instance. You can see how it looks in Figure 2.1.
 
+^^^ Figure 2.1. *Empty RavenDB node*
 ![Empty RavenDB node](./Ch02/img01.png)
+^^^
 
 What we have right now is a RavenDB node that is a self-contained cluster.[^1] 
 Now that we have a running node, the next step is to create a new database on this node. 

--- a/Ch02/Ch02.md
+++ b/Ch02/Ch02.md
@@ -118,9 +118,7 @@ an empty RavenDB instance. You can see how it looks in Figure 2.1.
 
 ![Empty RavenDB node](./Ch02/img01.png)
 
-What we have right now is a RavenDB node that is a self-contained cluster.^[Actually, that's not exactly the case, 
-but the details on the state of a newly minted node are a bit complex and covered in more detail in
-Chapter 6.] 
+What we have right now is a RavenDB node that is a self-contained cluster.[^1] 
 Now that we have a running node, the next step is to create a new database on this node. 
 
 You can do that by clicking the `Create Database` button, naming the new database `Northwind` and accepting all 
@@ -556,7 +554,7 @@ need. That's why most of the client API parts are customizable.
 Customizations can be applied by changing various settings and behaviors via the `DocumentStore.Conventions` property. For example,
 by default, the client API will use a property named `Id` (case sensitive) to store the document ID. But there are users
 who want to use the entity name as part of the property name. So they'll have OrderId for orders, ProductId for products, etc.
-^[I'll leave aside Id vs. ID, since it's handled in the same manner.]
+[^2]
 
 Here's how we tell the client API to apply the `TypeName + Id` policy:
 
@@ -681,8 +679,7 @@ document we tried to load wasn't found on the server, the dictionary will contai
 >
 > A session is limited by default to a maximum of 30 calls to the server. If you try to make more than 30 calls to the
 > server, an exception is thrown. This serves as an early warning that your code is generating too much load on the system
-> and is a circuit breaker.^[See [_Release It!_](http://pragprog.com/book/mnee/release-it), a wonderful book that heavily
-> influenced the RavenDB design.]
+> and is a circuit breaker.[^3]
 > 
 > You can increase the budget, of course, but just having that warning in place ensures that you'll think about the number of
 > remote calls you're making.
@@ -921,8 +918,7 @@ query to find documents that match a particular predicate, using LINQ.
 Like documents loaded via the `Load` call, documents that were loaded via a `Query` are managed by the session. Modifying
 them and calling `SaveChanges` will result in their update on the server. A document that was returned via a query and was
 loaded into the session explicitly via `Load` will still have only a single instance in the session and will retain all the
-changes that were made to it.^[You can call `session.Advanced.Refresh` if you want to force the session to update the state of
-the document from the server.]
+changes that were made to it.[^4]
 
 Queries in RavenDB don't behave like queries in a relational database. RavenDB doesn't allow computation during queries, and
 it doesn't have problems with table scans or slow queries. We'll touch on exactly why and cover details about indexing in
@@ -1017,8 +1013,7 @@ It's worth taking the time to read about, even if you'll rarely need the extra o
 >
 > * Because a generic interface doesn't expose the relevant (and useful) features of RavenDB, you're stuck with using the lowest
 >   common denominator. That means you give up a lot of power and flexibility, and in 99% of cases, the interface won't
->   allow you to switch between data store implementations.^[The 1% case where it will help is the realm of demo apps with 
->   little to no functionality]
+>   allow you to switch between data store implementations.[^5]
 > 
 > * The second situation is that, because of issues mentioned in the previous point, you expose the RavenDB features behind the  
 >   `IRepository`. In this case, you're already tied to the RavenDB client, but you added another layer that doesn't do much but 
@@ -1029,8 +1024,7 @@ It's worth taking the time to read about, even if you'll rarely need the extra o
 >
 > One thing that's absolutely wrong to do, however, is to have methods like `T IRepository.Get<T>(string id)` that will 
 > create and dispose of a session within the scope of the `Get` method call. That cancels out a _lot_ of optimizations, 
-> behaviors and functionality,^[`Unit of Work` won't work. Neither will change tracking, optimistic concurrency you'll have
-> to deal with manually, etc.] and it would be a real shame for you to lose these features of RavenDB.
+> behaviors and functionality,[^6] and it would be a real shame for you to lose these features of RavenDB.
 
 #### The Async Session
 
@@ -1140,8 +1134,7 @@ see in Figure 2.12. Amusingly enough, trying to include a raw emoji character br
 
 ![Unicode gave us Emojis, and the birdie document](./Ch02/img12.png)
 
-While going full-on emoji for document identifiers might be going too far^[Although, when you think about it, there's a huge 
-untapped market of teenage developers...], using Unicode for document IDs means that you don't have to worry if you need
+While going full-on emoji for document identifiers might be going too far[^7], using Unicode for document IDs means that you don't have to worry if you need
 to insert a Unicode character (such as someone's name).
 
 > **RavenDB and Unicode**
@@ -1237,9 +1230,7 @@ just handle that for us.
 > failures we stay up and are able to process requests and writes. On the other hand, it can create non-trivial complexities. 
 > 
 > If two clients try to create a new document on two nodes in parallel, we need to ensure that they will not accidentally create
-> documents with the same ID.^[If the user explicitly specified the document ID, there's nothing that RavenDB
-> _can_ do here. But for IDs that are being generated by RavenDB (client or server), we can do better than just hope that
-> we'll have no collisions.]
+> documents with the same ID.[^8]
 >
 > It's important to note, even at this early date, that such conflicts are part of life in any distributed database, and
 > RavenDB contains several ways to handle them (this is discussed in Chapter 6 in more detail). 
@@ -1344,8 +1335,7 @@ since they are easier to grasp. Identity has a real cost associated with it.
 
 The biggest problem with identities is that generating them in a distributed database requires us to do a lot more work than one
 might think. In order to prevent races, such as two clients generating the same identity on two different servers, part of the
-process of generating a new identity requires the nodes to coordinate with one another.^[This is done using the Raft consensus
-protocol, which covered in Chapter 6.] 
+process of generating a new identity requires the nodes to coordinate with one another.[^9] 
 
 That means we need to go over the network and talk to the other members in the cluster to guarantee we have the next
 value of the identity. That can increase the cost of saving a new document with identity. What's worse is that, under failure
@@ -1371,13 +1361,10 @@ There are also performance differences among the various methods that I want to 
 > per database mark. 
 
 RavenDB keeps track of the document IDs by storing them inside a B+Tree. If the document IDs are very big, it will mean that RavenDB can
-pack less of them in a given space.^[RavenDB is using B+Tree for on disk storage, and uses pages of 8KB in size. Bigger document IDs means
-that we can fit less entries in each page, and need to traverse down the tree, requiring us to do a bit more work to find the right document. 
-The same is true for saving unsorted document IDs, which can cause page splits and increase the depth of the tree. In nearly all cases,
-that doesn't really matter.] 
+pack less of them in a given space.[^10] 
 
 The `hilo` algorithm generates document IDs that are lexically sortable, up to a degree (`people/2-A` is sorted after 
-`people/100-A`). But with the exception of when we add a digit to the number^[Rolling from `99` to `100` or from `999` to `1000`.], values 
+`people/100-A`). But with the exception of when we add a digit to the number[^11], values 
 are nicely sorted. This means that for the most part we get nice trees and very efficient searches. It also generates the 
 most human-readable values.
 
@@ -1594,7 +1581,7 @@ There are two interesting things happening in the code in Listing 2.24. The code
 class, and it uses the `GetDocumentStore` method to get an instance of the document store. Let's break apart what's going on.
 
 The `RavenTestDriver<T>` class is the base test driver, which is responsible for setting up and tearing down databases. All 
-your RavenDB tests will use this class as a base class.^[Not strictly necessary, but this is the easiest way to build tests.] 
+your RavenDB tests will use this class as a base class.[^12] 
 Most importantly, from your point of view, is that the `RavenTestDriver<T>` class provides the `GetDocumentStore` method, which 
 generates a new in-memory database and is responsible for tearing it down at the end of the test. Each call to the 
 `GetDocumentStore` method will generate a _new_ database. It will run purely in memory, but other then that, it's fully functional and 
@@ -1654,8 +1641,7 @@ data, etc.). You can read all about its features in the online documentation.
 ### Summary
 
 At this point in the book, we've accomplished quite a lot. We started by setting up a development instance of RavenDB on
-your machine.^[The steps outlined in this chapter are meant to be quick and hassle-free, rather than an examination of
-proper production deployments. Check Chapter 15 for details on those.] And we learned how to set up a new 
+your machine.[^13] And we learned how to set up a new 
 database and played a bit with the provided sample database.
 
 We then moved to the most common tasks you'll do with RavenDB: 
@@ -1705,3 +1691,32 @@ test midway through and inspect the running RavenDB instance using the Studio.
 In this chapter, we started building the foundation of your RavenDB knowledge. In the next one, we'll build even further on that 
 foundation. We'll discuss modeling data and documents inside RavenDB and how to best structure your system to take advantage of what
 RavenDB has to offer.
+
+[^1]: Actually, that's not exactly the case, 
+but the details on the state of a newly minted node are a bit complex and covered in more detail in
+Chapter 6.
+[^2]: I'll leave aside Id vs. ID, since it's handled in the same manner.
+[^3]: See [_Release It!_](http://pragprog.com/book/mnee/release-it), a wonderful book that heavily
+influenced the RavenDB design.
+[^4]: You can call `session.Advanced.Refresh` if you want to force the session to update the state of
+the document from the server.
+[^5]: The 1% case where it will help is the realm of demo apps with 
+little to no functionality.
+[^6]: `Unit of Work` won't work. Neither will change tracking, optimistic concurrency you'll have
+to deal with manually, etc.
+[^7]: Although, when you think about it, there's a huge untapped market of teenage developers...
+[^8]: If the user explicitly specified the document ID, there's nothing that RavenDB
+_can_ do here. But for IDs that are being generated by RavenDB (client or server), we can do better than just hope that
+we'll have no collisions.
+[^9]: This is done using the Raft consensus protocol, which covered in Chapter 6.
+[^10]: RavenDB is using B+Tree for on disk storage, and uses pages of 8KB in size. Bigger document IDs means
+that we can fit less entries in each page, and need to traverse down the tree, requiring us to do a bit more work to find the right document. 
+The same is true for saving unsorted document IDs, which can cause page splits and increase the depth of the tree. In nearly all cases,
+that doesn't really matter.
+[^11]: Rolling from `99` to `100` or from `999` to `1000`.
+[^12]: Not strictly necessary, but this is the easiest way to build tests.
+[^13]: The steps outlined in this chapter are meant to be quick and hassle-free, rather than an examination of
+proper production deployments. Check Chapter 15 for details on those.
+
+
+

--- a/Ch03/Ch03.md
+++ b/Ch03/Ch03.md
@@ -54,8 +54,7 @@ address it was shipped to but rather the _current_ customer address.
 > home, so they applied for a mortgage. As part of that, they had to submit paystubs from the past several months. The 
 > employee asked her HR department to send over her most recent stubs. When the bank saw paystubs made to an 
 > account that didn't exist, they suspected fraud. The mortgage was denied and the police were called. An 
-> unpleasant situation all around.^[This ended up being sorted out eventually by uttering the magic words: "computer error." 
-> But it was very exciting for a while there.]
+> unpleasant situation all around.[^1]
 
 It's common for this issue to be blamed on bad modeling decisions (and I agree). The problem is that 
 a more appropriate model is complex to build and work with, expensive to query and hard to reason about in 
@@ -70,9 +69,7 @@ A document database like RavenDB doesn't solve this problem completely. It's ent
 be a poor fit for the way RavenDB stores data. However, the way most business applications (and in general OLTP systems) 
 think about their data is an excellent fit for RavenDB.
 
-You can read more about this by looking at `Domain Driven Design`^[The 
-[book]( https://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215) is a bit dry, but I remember 
-being very impressed when I read it the first time.] and, in particular, about the concept of an `Aggregate Root`.
+You can read more about this by looking at `Domain Driven Design`[^2] and, in particular, about the concept of an `Aggregate Root`.
 
 > **What are aggregates?**
 >
@@ -185,7 +182,7 @@ A great trick for document modeling is to consider the data as, well...documents
 world apply to document modeling.
 
 If I hand you a document and tell you that you need to fill out _this_ form and then go and update _that_ form, you'll rightly consider 
-the process a normal government behavior/bureaucratic/Kafkaesque.^[Circle the appropriate choice] If I gave you a form and told you 
+the process a normal government behavior/bureaucratic/Kafkaesque.[^3] If I gave you a form and told you 
 that, in order to understand it, you had to consult another document...you get my point.
 
 When modeling, I find that it helps to picture the document in its printed form. If it makes sense as a printed page, it's 
@@ -290,7 +287,7 @@ to our kindergarten.
 
 All of the information is in one place. For the document ID you can see that we used a semantic ID, `children/alice-liddell`, which includes the child name. This 
 works well for data that's well known and predictable. The data itself is centrally located and easy to access. Looking at the data,
-it's easy to see all relevant information about our Alice.^[Except maybe which rabbit hole she wandered down...]
+it's easy to see all relevant information about our Alice.[^4]
 
 For the most part, embedding information is our default approach because it leads us to more coherent documents, which contain all the 
 information relevant to processing them. We aren't limited by format of schema; we can represent arbitrarily complex data
@@ -302,8 +299,7 @@ that's the primary force for splitting the document apart.
 
 In the case of the kindergarten record, the obvious example here are the parents. Henry and Lorina are independent entities and are not 
 fully owned by the Alice record. We need to split them into independent documents. On the other side of things, Henry and Lorina have more
-children than just Alice: there's also Harry and Edith.^[The real Harry and Lorina had a total of 
-[10 children](https://en.wikipedia.org/wiki/Alice_Liddell), by the way.] So we need to consider how to model such information.
+children than just Alice: there's also Harry and Edith.[^5] So we need to consider how to model such information.
 
 #### Many-to-one relationship
 
@@ -327,7 +323,7 @@ the data so there's a distinct difference between the different entities. You ca
 }
 ```
 
-Listing 3.3 shows^[I removed all extra information from the documents to make it clearer.] both Alice and Henry (you can figure out what 
+Listing 3.3 shows[^6] both Alice and Henry (you can figure out what 
 Edith's document looks like on your own) with references to their parents. 
 I've intentionally not included semantic IDs for the parents to avoid confusion about what information is stored on the side holding the
 reference. Alice and Henry (and Edith) only hold the _identifier_ for their parents' documents, nothing else.
@@ -634,7 +630,7 @@ In short, there's a _lot_ of work going on, and it can be very expensive. On the
 typically need to read many of them to get anything meaningful done, which means a lot of work for the database engine.
 
 Here's the rule of thumb we use: as long as it makes sense to measure the document size in kilobytes, you're good. RavenDB will generate 
-a warning in the Studio when it encounters documents that are too large,^[By default, that's set to 5 MB, and it's configurable.] but it has no impact whatsoever on the behavior or performance of the system. 
+a warning in the Studio when it encounters documents that are too large,[^7] but it has no impact whatsoever on the behavior or performance of the system. 
 
 There are two common reasons why a document can be very large. Either it holds a single (or a few) very large properties, such as a lot of text, binary data, etc., or it contains a collection whose size is not bounded.
 
@@ -727,8 +723,7 @@ in lost updates and invalid data. How does RavenDB handle concurrency, and how d
 
 #### Concurrency control
 
-RavenDB is inherently concurrent, capable of handling hundreds of thousands^[Not a typo! In our benchmarks, we're always saturating the
-network long before we saturate any other resource, so the current limit is how fast your network cards are in packet processing.] 
+RavenDB is inherently concurrent, capable of handling hundreds of thousands[^8] 
 of requests per second.
 
 That leads to a set of interesting problems regarding concurrency. What happens if two requests are trying to modify the same document at
@@ -837,8 +832,7 @@ querying and `Include` when fetching the data from the server.
 
 RavenDB is a JSON document database, but not all data can be (or should be) represented in JSON. This is especially true when you consider 
 that a document might reasonably include binary data. For example, when working with an order document, the invoice PDF might
-be something we need to keep.^[A signed PDF invoice is pretty common, and you're required to keep it for tax purposes and can't just
-generate it on the fly]. If we have a user document, the profile picture is another piece of binary data that is both part of the 
+be something we need to keep.[^9]. If we have a user document, the profile picture is another piece of binary data that is both part of the 
 document and separate from it.
 
 RavenDB's answer to that need is attachments. Attachments are binary data that can be attached to documents. An attachment is always on a
@@ -860,8 +854,7 @@ use case for attachments in RavenDB.
 
 #### Revisions and Auditing
 
-Tracking changes in data over time is a challenging task. Depending on the domain in question,^[This is common in insurance and
-healthcare, for example.] we need to be able to show all changes that happened to a document. RavenDB supports that with its revisions
+Tracking changes in data over time is a challenging task. Depending on the domain in question,[^10] we need to be able to show all changes that happened to a document. RavenDB supports that with its revisions
 feature.
 
 The database administrator can configure RavenDB to keep track of document revisions. Whenever a document is changed, an immutable 
@@ -870,7 +863,7 @@ only specific collections and to only keep track of the last N revisions, but of
 disk space is relatively cheap and those domains need this accountability. It's better to keep too much than not enough.
 
 Revisions also can apply to deletes, so you can restore a deleted document if you need to. One way of looking at revisions is as a way
-to have a copy of all changes on a per-document level.^[Obviously, this does not alleviate the need to have proper backups.] 
+to have a copy of all changes on a per-document level.[^11] 
 
 Auditing is a _bit_ different. While revisions tell you _what_ changed, auditing tells you by _whom_ and typically what _for_. RavenDB
 supports this kind of auditing using client-side listeners, which can provide additional context for the document whenever it's changed.
@@ -902,7 +895,7 @@ In RavenDB, all operations on a document or attachment using its ID (put, modify
 multiple separate transactions instead of one very big one. 
 
 By default, when you save a document into RavenDB, we'll acknowledge the write when the data has been saved on one node in a durable 
-fashion.^[That means that the data has been written to disk and fsync() or the equivalent was called, so the data is safe from power loss.]
+fashion.[^12]
 You can also ask the write to be acknowledged only when the write has been made durable on multiple nodes (using 
 the `WaitForReplicationAfterSaveChanges` method) for additional safety. We discuss all such details in 
 Chapter 6.
@@ -957,7 +950,7 @@ The `BASE` on indexing behavior is optional. You can ask RavenDB to wait for the
 so you have the option of choosing. If this is a write you intend to immediately query, you can force a wait. Usually, that isn't required, so
 you don't need to pay the cost here. 
 
-You need to be aware of the distinctions here between queries (which can be `BASE` and lag a bit^[The typical lag time for indexing is under 1 ms]) and 
+You need to be aware of the distinctions here between queries (which can be `BASE` and lag a bit[^13]) and 
 bulk operations (many small transactions) and operations on specific documents (either one at a time or in groups), which happen as `ACID` transactions.
 Taking advantage of the `BASE` nature of indexing allows you to reduce the cost of querying and writing, as well as selectively apply the decision
 on a case-by-case basis.
@@ -991,8 +984,7 @@ We looked at handling binary data with attachments, as well as auditing and chan
 in RavenDB. Reference handling at indexing and query time was briefly covered (we'll cover it in depth in Chapter 9), as it's important
 to how you model your documents.
 
-A repeating theme was the use of semantic IDs to give you better control over documents and their meaning &mdash; not so much for RavenDB's sake^[The database 
-doesn't care what your document IDs look like.] but because it increases understanding and visibility in your domain. Using document IDs to "nest" documents
+A repeating theme was the use of semantic IDs to give you better control over documents and their meaning &mdash; not so much for RavenDB's sake[^14] but because it increases understanding and visibility in your domain. Using document IDs to "nest" documents
 such as `accounts/1234/tx/2017-05` or having meaningful document IDs such as `config/states` helps a lot in setting out the structure for your model.
 
 The final topic we covered was `ACID` vs. `BASE` in RavenDB. Documents in RavenDB are stored and accessed in an `ACID` manner, while we default
@@ -1001,3 +993,24 @@ can select the appropriate mode for each scenario.
 
 Our next chapter is going to cover the client API in depth, going over all the tools that you have to create some really awesome behaviors. After that, we'll
 get to running clusters of RavenDB and understanding how the distributed portion of RavenDB is handled.
+
+[^1]: This ended up being sorted out eventually by uttering the magic words: "computer error." 
+But it was very exciting for a while there.
+[^2]: The [book]( https://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215) is a bit dry, but I remember 
+being very impressed when I read it the first time.
+[^3]: Circle the appropriate choice.
+[^4]: Except maybe which rabbit hole she wandered down...
+[^5]: The real Harry and Lorina had a total of [10 children](https://en.wikipedia.org/wiki/Alice_Liddell), by the way.
+[^6]: I removed all extra information from the documents to make it clearer.
+[^7]: By default, that's set to 5 MB, and it's configurable.
+[^8]: Not a typo! In our benchmarks, we're always saturating the 
+network long before we saturate any other resource, so the current limit is how fast your network cards are in packet processing.
+[^9]: A signed PDF invoice is pretty common, and you're required to keep it for tax purposes and can't just
+generate it on the fly.
+[^10]: This is common in insurance and healthcare, for example.
+[^11]: Obviously, this does not alleviate the need to have proper backups.
+[^12]: That means that the data has been written to disk and fsync() or the equivalent was called, so the data is safe from power loss.
+[^13]: The typical lag time for indexing is under 1 ms.
+[^14]: The database doesn't care what your document IDs look like.
+
+

--- a/Ch04/Ch04.md
+++ b/Ch04/Ch04.md
@@ -1011,7 +1011,7 @@ if something might have changed, we'll check the server for the most up-to-date 
 > the requirement that aggressive caching must be turned on explicitly, you're aware that there's a period of time where the response you receive might have
 > diverged from the result on the server.
 
-**Caching behavior in a cluster**
+> **Caching behavior in a cluster**
 >
 > Typically, RavenDB is deployed in a cluster, and a database will reside on multiple machines. How does caching work in this context? 
 > The caching is built on the full URL of the request, and that takes into account the particular server that we'll be making the request to. That means that the cache

--- a/Ch04/Ch04.md
+++ b/Ch04/Ch04.md
@@ -301,7 +301,7 @@ The `Lock` method returns an `IDisposable` instance that handles releasing the l
 > to show how you'd use several different features at once to achieve a goal. 
 >
 > Actually handling a distributed lock is a non-trivial issue. Consider a RavenDB cluster with multiple nodes. If two lock requests go to two
-> distinct nodes at the same time, _both_ of them will succeed.^[We'll discuss in detail how RavenDB clusters work in the next chapter.]  The two nodes
+> distinct nodes at the same time, _both_ of them will succeed.[^1] The two nodes
 > will quickly discover the conflicting updates and generate a conflict. But it isn't guaranteed they'll discover it inside
 > the lock/unlock period. 
 > 
@@ -508,7 +508,7 @@ The available commands range from putting and deleting documents and attachments
 operation, the rest are only useful in rare cases. The most common use of `Defer` beyond patch is when you need fine-grained control over the operations
 that will be executed in a single transaction, to the point where you want to control the ordering of the operations.
 
-RavenDB doesn't allow changing the document's collection, you can't just update the `@collection` metadata. So, if you need to do this,^[And this should be a very rare thing indeed.] you must first delete the old document and then create a new one with the appropriate collection. The session doesn't allow you to both
+RavenDB doesn't allow changing the document's collection, you can't just update the `@collection` metadata. So, if you need to do this,[^2] you must first delete the old document and then create a new one with the appropriate collection. The session doesn't allow you to both
 delete and modify a document. And for the purpose of discussion, let's say that we _have_ to make this in a single transaction, so no other client sees a 
 point in time where the document was deleted.
 
@@ -562,8 +562,7 @@ is the absolute worst way you can write a large amount of documents into RavenDB
 between the client and the application. For each request, we have to make another REST call, send a packet to the server, etc. On the other side, the server accepts
 a new request, processes it and commits it to disk. During the entire process, it's effectively idle, since most of the time is spent waiting for I/O. That's a big waste all around.
 
-You can see the various times nicely when looking at the Fiddler^[The [Fiddler web proxy](http://www.telerik.com/fiddler) is a great debugging tool in general, and is 
-quite useful to peek into the communication between RavenDB's server and clients.] statistics. Each request takes about 220&ndash;260 milliseconds to run. Writing the first
+You can see the various times nicely when looking at the Fiddler[^3] statistics. Each request takes about 220&ndash;260 milliseconds to run. Writing the first
 1,000 documents took four minutes and six seconds, and 2,000 requests took eight minutes on the dot. The full 10,000 documents would take 40 minutes or so. 
 Granted, we're intentionally going to a remote server, but still... 
 
@@ -630,7 +629,7 @@ Console.WriteLine(sp.Elapsed);
 The code in Listing 4.16 is also using a local method, which is a new C# 7.0 feature. It allows you to package a bit of behavior quite nicely, and it's very useful for
 small demos and internal async code. This code writes 1,000 documents in just under 10 seconds, and it completes the full 10,000 writes in under 30 seconds (29.6, on
 my machine). The speed difference is, again, related to the client learning our pattern of behavior and adjusting itself accordingly (creating enough buffers, threads
-and other resources needed; warming up the TCP connections.^[TCP slow start can be a killer on benchmarks.])
+and other resources needed; warming up the TCP connections.[^4])
 
 However, we really had to make an effort. We wrote explicit async code and managed it, rate-limited our behavior and jumped through several hoops to get a more reasonable level of 
 performance. Note that we went from over 40 minutes to less than 30 seconds in the span of a few pages. Also note that we haven't actually modified _what_ we're doing &mdash; we only changed how we're talking to the server &mdash; but it had a huge impact on performance.
@@ -710,7 +709,7 @@ bulk insert request is the primary reason we cut our costs by two-thirds on the 
 
 I talked about this a few times already, but it's important. The latency of going to the server and making a remote call is often much higher than the
 cost of actually processing the request on the server. On the local machine, you'll probably not notice it much. That's normal for running in a
-development environment. When you go to production, your database is typically going to run on a dedicated machine,^[In fact, it's likely that a database cluster will be used on a set of machines.] so you'll have to go over the network to get it. And that dramatically increases the cost of going to the database.
+development environment. When you go to production, your database is typically going to run on a dedicated machine,[^5] so you'll have to go over the network to get it. And that dramatically increases the cost of going to the database.
 
 This problem is well known: it's the [fallacies of distributed computing](https://en.wikipedia.org/wiki/Fallacies_of_distributed_computing). RavenDB handles the issue in several ways. A session has a budget on the number of remote calls it can make. (This is controlled by
 `session.Advanced.MaxNumberOfRequestsPerSession`.) If it goes over that limit, an exception is thrown. We had this feature from the get-go, and that
@@ -733,8 +732,7 @@ using (var session = store.OpenSession())
 
 A scenario like the one outlined in Listing 4.18 is incredibly common. We have many cases where we need to show the user information from multiple sources,
 and that's a concern. Each of those calls turns out to be a _remote_ call, requiring us to go over the network. There are ways to optimize this specific
-scenario. We can define a MapReduce index and run a query and `Include` on it. We haven't yet gone over exactly what this means,^[We'll cover this technique
-when we discuss MapReduce indexes in Chapter 11.] but this is a pretty complex solution, and it isn't relevant when you have different 
+scenario. We can define a MapReduce index and run a query and `Include` on it. We haven't yet gone over exactly what this means,[^6] but this is a pretty complex solution, and it isn't relevant when you have different 
 types of queries. If we wanted to also load the logged-in user, for example, that wouldn't work.
 
 RavenDB's solution for this issue is the notion of lazy requests. A lazy request isn't actually being executed when you make it. Instead, it's 
@@ -818,7 +816,7 @@ If there are 30 results in all, that's great, but if we have 30,000, we'll likel
 results _from_ the network and then populating a list of 30,000 (potentially complex) objects is going to take some time. In terms of memory usage, we'll need
 to hold all those results in memory, possibly for an extended period of time.
 
-Due to the way memory management works in .NET,^[The behavior on the JVM is the same. Other clients environment have different policies.] allocating a list with
+Due to the way memory management works in .NET,[^7] allocating a list with
 a lot of objects over a period of time (because we are reading them from the network) will likely push the list instance, and all of its contents, into a higher
 generation. This means that, when you're done using it, the memory will not be collected without a more expensive `Gen1` or even `Gen2` round. 
 
@@ -1122,8 +1120,7 @@ using (var session = store.OpenSession())
 There are a few things to note in Listing 4.26. First, we no longer include the `Customer` in the query. We don't need that because the result of this query isn't a list
 of `SupportCall` documents but a list of projections that already include the `CustomerName` that we want. The key part, as far as we're concerned, is the call to the 
 `session.Load<Customer>()` method. This is translated into a server side load operation that fetches the related `Customer` document and extracts just the `Name` field from
-it.^[This is possible because we are using a synchronous session and queries. If we were using async queries, we'll need to use `RavenQuery.Load<Customer>` in the Linq 
-query.]
+it.[^8]
 
 The output of a query like the one in Listing 4.26 is not a document, it is a projection and as a result of that, it isn't tracked by the session. 
 This means that changes to a projection won't be saved back to the server when `SaveChanges` is called. You _can_ call `Store` on the result of a projection, but be 
@@ -1259,7 +1256,7 @@ in Listing 4.29). It was quite interesting to see how much value she got out of 
 
 In terms of cost, revisions obviously increase the amount of disk space required. But given today's disk sizes, that isn't usually a significant concern. Aside
 from disk space utilization, revisions don't actually have any impact on the system. Revisions are also quite important for ensuring that transaction boundaries are respected
-when replicating changes in the cluster^[See "Transaction atomicity and replication" in Chapter 6.], handling historical subscriptions^[See "Versioned Subscriptions" in the next chapter.] and ETL processes.
+when replicating changes in the cluster[^9], handling historical subscriptions[^10] and ETL processes.
 
 > **Revisions from an older version of your software**
 >
@@ -1281,7 +1278,7 @@ with JSON documents in their stringified form &mdash; a set of UTF8 characters w
 But JSON parsing requires you to work in a streaming manner, which means that to pull up just a few values from a big document, you still need to
 parse the full document. As it turns out, once a document is inside RavenDB, there are a _lot_ of cases where we want to just get a couple of values 
 from it. Indexing a few fields is common, and parsing the JSON each and every time can be incredibly costly. Instead, RavenDB accepts the JSON
-string on write and turns it into an internal format called blittable.^[I don't like the name, but we couldn't come up with anything better.] 
+string on write and turns it into an internal format called blittable.[^11] 
 
 A blittable JSON document is a format that allows RavenDB random access to any piece of information in the document without having to parse the 
 document, with a traversal cost of (amortised) O(1). Over the wire, RavenDB is sending JSON strings, but internally, it's all blittable.
@@ -1305,7 +1302,7 @@ the events that the client API exposes to us.
 
 We looked at how change tracking is managed and how we can get detailed information from the session about what exactly changed in our documents. Then we
 examined how we should handle concurrency in our application. We looked at optimistic concurrency in RavenDB and even implemented _pessimistic_ 
-locking.^[Although you shouldn't probably use that in real production code.] Online optimistic concurrency can be handled for us automatically by the 
+locking.[^12] Online optimistic concurrency can be handled for us automatically by the 
 session, or we can send the change vector value to the client and get it back on the next request, thus implementing offline optimistic concurrency.
 
 There's another way to handle concurrency &mdash; or just to save yourself the trouble of shuffling lots of data between client and server &mdash; and that way is to use patching. The client API offers patching 
@@ -1358,3 +1355,18 @@ be useful in specific, narrow circumstances or only make sense to talk about in 
 we'll do so extensively when we get to Chapter 11 and when we discuss indexing.
 
 The next chapter is a good example of this. We'll dedicate that chapter to handling data subscriptions and all the myriad ways they make data processing tasks easier for you.
+
+[^1]: We'll discuss in detail how RavenDB clusters work in the next chapter.
+[^2]: And this should be a very rare thing indeed.
+[^3]: The [Fiddler web proxy](http://www.telerik.com/fiddler) is a great debugging tool in general, and is 
+quite useful to peek into the communication between RavenDB's server and clients.
+[^4]: TCP slow start can be a killer on benchmarks.
+[^5]: In fact, it's likely that a database cluster will be used on a set of machines.
+[^6]: We'll cover this technique when we discuss MapReduce indexes in Chapter 11.
+[^7]: The behavior on the JVM is the same. Other clients environment have different policies.
+[^8]: This is possible because we are using a synchronous session and queries. If we were using async queries, we'll need to use `RavenQuery.Load<Customer>` in the Linq 
+query.
+[^9]: See "Transaction atomicity and replication" in Chapter 6.
+[^10]: See "Versioned Subscriptions" in the next chapter.
+[^11]: I don't like the name, but we couldn't come up with anything better.
+[^12]: Although you shouldn't probably use that in real production code.

--- a/Ch05/Ch05.md
+++ b/Ch05/Ch05.md
@@ -97,8 +97,7 @@ and keep a connection open to the server, getting fed with all the documents tha
 
 Once we've gone over all the documents currently in the database, the subscription will go to sleep but remain connected to the server. Whenever a new
 or updated document matches the subscription query, it will be sent to the subscription. Errors during this process, either in the network, the server or the client, are
-tolerated and recoverable. The subscription will ensure that a client will receive each matching document at least once.^[Although errors may cause you to receive 
-the same document multiple times, you're guaranteed to never miss a document.] 
+tolerated and recoverable. The subscription will ensure that a client will receive each matching document at least once.[^1] 
 
 > **Subscription in a cluster**
 >
@@ -355,11 +354,11 @@ sent, the code in Listing 5.6 will have no issue. We'll never skip sending an em
 >
 > For one project, we had to restart the coordinator and manually resolve hanging transactions on a biweekly basis, and it wasn't a 
 > very large or busy website. [Joe Armstrong](https://en.wikipedia.org/wiki/Joe_Armstrong_(programming)), inventor of Erlang,
-> described^[This particular lecture was over a decade ago, but I still vividly remember it. It was _that_ good.] the problem far better than I 
+> described[^2] the problem far better than I 
 > could:
 >
 > > The "Two Generals' Problem" is reality, but the computer industry says it doesn't believe 
-> > in mathematics: two-phase commit^[There's also the _three_-phase commit, which just adds to the fun and doesn't actually solve the issue.] 
+> > in mathematics: two-phase commit[^3] 
 > > always works!
 
 There's another issue with the code in Listing 5.5 and Listing 5.6. They're incredibly wasteful in the number of remote calls that they're making. One of 
@@ -419,8 +418,7 @@ a single `SaveChanges` with all the changes for all the support calls in the bat
 
 Note that we're relying on the `Unit of Work` nature of the session. Once we've loaded a document into it, trying to load it again will give us the already loaded
 version without going to the server. Without this feature, the amount of calls to `Load` would have probably forced us over the budget of remote calls allowed
-for the session.^[Remember, that budget is configurable, but it's  mostly there to help you realize that generating so many requests is probably not healthy for 
-you.]
+for the session.[^4]
 
 Listing 5.7 takes full advantage of the batch nature of subscriptions. In fact, the whole reason why the batch exposes the `Items` list property instead of just being
 an enumerable is to allow you to make those kinds of optimizations. By making it obvious that scanning the list of items per batch is effectively free, we're 
@@ -669,7 +667,7 @@ to the client-side types.
 ### Error handling and recovery with subscriptions
 
 What happens when there's an error in the processing of a document? Imagine that we had code inside the lambda in the `Run` method and that code threw an 
-exception. Unless you set `SubscriptionWorkerOptions.IgnoreSubscriberErrors`,^[And you probably shouldn't do that.] we'll abort processing of the 
+exception. Unless you set `SubscriptionWorkerOptions.IgnoreSubscriberErrors`,[^5] we'll abort processing of the 
 subscription and the `Run` will raise an error. Typical handling in that scenario is to dispose the subscription and immediately open it again. 
 
 Assuming the error is transient, we'll start processing from the last batch we received and continue forward from there. If the error isn't transient &mdash; for example,
@@ -863,8 +861,7 @@ for handling subscriptions also allows you to split your processing between the 
 > That scenario should be rare, and it will only last for the duration of a single batch, until the next synchronization point for the subscription (which ensures global consistency for the subscription). One of those servers will fail to process the batch acknowledgement and return that error to the client, eventually
 > aborting the connection. 
 
-You may decide that you want certain operations to be handled on one worker node^[I'm using the term worker node here to refer to machines that are running business processes, 
-subscriptions, etc. This is to distinguish them from RavenDB nodes.] and configure those subscriptions to `TakeOver` on that worker node and `WaitForFree`
+You may decide that you want certain operations to be handled on one worker node[^6] and configure those subscriptions to `TakeOver` on that worker node and `WaitForFree`
 on any other worker nodes. This way, a particular subscription has a preferred worker node that it will run on, but if that one fails, it will run on another.
 In other words, each worker node will run only its own preferred subscriptions unless there's a failure. 
 
@@ -998,8 +995,7 @@ based on the changes that happened to the entity.
 
 This feature opens up a _lot_ of options regarding analytics because you aren't seeing just a snapshot of the state but all the intermediate steps along the 
 way. This has uses in business analytics, fraud, outliers detection and forensics, in addition to the general benefit of being able to reconstruct the flow of data through your system. 
-The way versioned subscriptions work, we're going to get all the changes that match our criteria, in the same order they happened in the database.^[Again, 
-different nodes may have observed the events in a different order, but it should roughly match across the cluster.]
+The way versioned subscriptions work, we're going to get all the changes that match our criteria, in the same order they happened in the database.[^7]
 
 If I wrote to `customers/8243-C`, created a new `customers/13252-B` and then wrote to `customers/8243-C` again, I'll get the changes (either in a single batch 
 or across batches) in the following order:
@@ -1161,8 +1157,7 @@ email-sending example, including how to handle failures and partial failures bot
 
 > **Using subscription for ETL work**
 >
-> It's tempting to use subscriptions to handle ETL^[Extract, transform, load &mdash; the process of moving data around between different data storage 
-> systems.] tasks, such as writing to a reporting database. While it _is_ possible, RavenDB has better options to handle ETL. See the discussion on this 
+> It's tempting to use subscriptions to handle ETL[^8] tasks, such as writing to a reporting database. While it _is_ possible, RavenDB has better options to handle ETL. See the discussion on this 
 > topic in Chapter 8.
 
 We spent a lot of time discussing how to handle errors in subscriptions, how to deploy subscriptions into production and how we can ensure failover and load balancing
@@ -1180,3 +1175,14 @@ from both old and new revisions of the document to the client side.
 
 The next part of the book is going to be exciting. We're going to learn how RavenDB is working in a distributed environment, and we can finally figure out what
 all those cryptic references to working in a cluster _mean_.
+
+[^1]: Although errors may cause you to receive the same document multiple times, you're guaranteed to never miss a document.
+[^2]: This particular lecture was over a decade ago, but I still vividly remember it. It was _that_ good.
+[^3]: There's also the _three_-phase commit, which just adds to the fun and doesn't actually solve the issue.
+[^4]: Remember, that budget is configurable, but it's  mostly there to help you realize that generating so many requests is probably not healthy for 
+you.
+[^5]: And you probably shouldn't do that.
+[^6]: I'm using the term worker node here to refer to machines that are running business processes, 
+subscriptions, etc. This is to distinguish them from RavenDB nodes.
+[^7]: Again, different nodes may have observed the events in a different order, but it should roughly match across the cluster.
+[^8]: Extract, transform, load &mdash; the process of moving data around between different data storage systems.

--- a/Ch06/CH06.md
+++ b/Ch06/CH06.md
@@ -3,8 +3,7 @@
 
 [Clustering Setup]: #clustering-setup
 
-You might be familiar with the term "murder of crows" as a way to refer to a group of crows.^[If you're interested in
-learning why, I found this answer fascinating: https://www.quora.com/Why-is-a-group-of-crows-called-a-murder ] It's
+You might be familiar with the term "murder of crows" as a way to refer to a group of crows.[^1] It's
 been used in literature and the arts many times. Of less renown is the group term for ravens, which is "unkindness." 
 Personally, in the name of all ravens, I'm torn between being insulted and amused. 
 
@@ -1095,3 +1094,5 @@ manage distributed state in a reliable way by leaning on the consensus protocol 
 
 In the next chapter, we are going to cover how to design your cluster, how to define your topology for geo-distributed environments, and, in general, how to scale your RavenDB
 cluster.
+
+[^1]: If you're interested in learning why, I found this answer fascinating: https://www.quora.com/Why-is-a-group-of-crows-called-a-murder

--- a/Ch06/CH06.md
+++ b/Ch06/CH06.md
@@ -17,10 +17,7 @@ the benefit of that sooner.
 
 ### An overview of a RavenDB cluster
 
-A RavenDB cluster is three or more machines^[It doesn't make a lot of sense to have a cluster with just two nodes since 
-we'll require both of the nodes to always be up, in most cases. There are certain advanced scenarios where such topology 
-might make sense, and we'll touch on that briefly in Chapter 7.] 
-that have been joined together. 
+A RavenDB cluster is three or more machines[^2] that have been joined together. 
 
 But what's the point of doing that? Well, you can create databases on a RavenDB cluster, and you can specify that the 
 cluster should manage them on its own. A database can live on a single node, some number of the nodes or even all the 
@@ -71,7 +68,7 @@ That means that each node can operate on its own internal state for most operati
 However, if a majority of the nodes aren't available, we can't proceed. This is pretty much par for the course for consensus 
 algorithms. Another issue with consensus algorithms is that they incur additional network round trips for each operation. 
 For cluster maintenance and the configuration of databases, RavenDB uses the Raft consensus protocol. The RavenDB 
-implementation of Raft is codenamed Rachis.^[Rachis is the central shaft of pennaceous feathers.]
+implementation of Raft is codenamed Rachis.[^3]
 
 Databases, on the other hand, are treated quite differently. Each node in the cluster has a full copy of the topology, 
 which specifies which nodes host which databases. That information is managed by Rachis, but each node is able to act
@@ -255,8 +252,7 @@ couldn't elect a leader. But what does this mean? Well, it means that during the
 
 Cluster-wide operations include creating a new database and monitoring the health of other nodes. But a lot of database-specific configuration 
 (anything that impacts all instances of a database) goes through the cluster as well. For example, we won't be able to schedule 
-a backup task with the cluster down,^[Of course, we'll be able to create a backup manually. See the discussion about cluster-wide 
-tasks later in this chapter.] and you'll not be able to deploy new indexes or modify database configurations. 
+a backup task with the cluster down,[^4] and you'll not be able to deploy new indexes or modify database configurations. 
 
 > **Operations in a failed cluster**
 >
@@ -308,8 +304,7 @@ The "Spade" database is marked as remote because it doesn't reside on this node.
 For one thing, databases that we manually configured are going to remain on the nodes they've been configured to run on. It also appears
 that we can see the entire cluster topology from every node. 
 
-Now, let's actually use our cluster and create a new database. We'll call it "Pitchfork."^[I'm on a garden tools naming streak, it 
-appears.] Everyone knows that a proper pitchfork has three tines; the four-tine pitchfork is used for shoveling, while 
+Now, let's actually use our cluster and create a new database. We'll call it "Pitchfork."[^5] Everyone knows that a proper pitchfork has three tines; the four-tine pitchfork is used for shoveling, while 
 a novel three-tine pitchfork is the favorite tool of Poseidon. As such, it's only natural that our "Pitchfork" database will 
 have a replication factor of three. Once that's done, we'll just create the database and observe the results.
 
@@ -432,9 +427,7 @@ layer, where each database instance works on its own, without relying on its sib
 
 That has a lot of implications on how RavenDB works. On the client side, if the client is unable to talk to a node (TCP error, HTTP 503, 
 timeouts, etc.), it will assume that this particular node is down and will switch to the next node in the list. All the clients get their
-topology from the cluster, and the cluster ensures that we'll always report the same topology to the clients.^[Of course, it's possible 
-that a client has an _outdated view_ of the topology, but there are mechanisms in place to ensure that clients will figure out that their 
-topology is out of date and refresh it.] 
+topology from the cluster, and the cluster ensures that we'll always report the same topology to the clients.[^6] 
 
 By default, all the clients will talk to the first node in the database group topology. We usually call this the preferred node, and any of the other
 nodes in the topology are called the alternates. A failure of any of the alternates wouldn't even register for the typical client configuration since
@@ -578,8 +571,7 @@ Transactions in RavenDB are _important_. Relying on ACID transactions reduces a 
 given that RavenDB transactions are _not_ distributed, it's interesting to consider how the transactional guarantees are preserved in a 
 distributed cluster.
 
-Consider for a moment the code in Listing 6.3. It's a simple bank transaction that moves $10 from my account to yours,^[This isn't even
-close to how money transfers really work, of course, but it's a classic example and easy to reason about.], which I'm sure will be a 
+Consider for a moment the code in Listing 6.3. It's a simple bank transaction that moves $10 from my account to yours[^7], which I'm sure will be a 
 delightful surprise.
 
 ```{caption="The classic bank transaction example" .cs }
@@ -659,8 +651,7 @@ transaction in Listing 6.3 as it was so that a client observing a second node ca
 As you can see, revisions are a very powerful feature, and they're used in more scenarios than might initially be expected. The idea 
 behind relying on revisions to handle transaction consistency is that, in many cases, it doesn't matter. A proper document model follows the
 isolated, independent and coherent tenets, which usually means you don't _need_ this feature. But when you do, and most certainly it will
- come up,^[It's not something you'll use for everything, but in most applications there's one or two places where it can
-be _really_ useful.] the key here is that you aren't paying for tracking all the intermediate values unless you actually need this. 
+ come up,[^8] the key here is that you aren't paying for tracking all the intermediate values unless you actually need this. 
 
 A lot of RavenDB features use the "pay to play" model, meaning if you aren't using a specific feature, you don't need to pay the performance 
 cost of supporting it.
@@ -736,8 +727,7 @@ The question is this &mdash; how are we going to handle such a case? Let's gener
 But first, we need to disable automatic conflict resolution so we can observe what is going on behind
 the scenes. In the Studio, go to `Settings`, `Conflict Resolution`. This is where you let RavenDB know how
 you want it to resolve conflicts when they happen. By default, we resolve conflicts in favor of the most 
-recent version^[Note that different nodes may have different clocks. RavenDB doesn't attempt to compensate
-for this and will use the latest timestamp from the conflicts in its automatic resolution.]. You can see
+recent version[^9]. You can see
 what this look like in Figure 6.14.
 
 ![Configuring server side conflict resolution policy in the Studio](./Ch06/img14.png)
@@ -903,7 +893,7 @@ In Chapter 2, I introduced the compare exchange feature (sometimes known as `cmp
 compare and swap operations at the cluster level. As you can imagine, this feature relies on the strong consistency available to 
 the RavenDB cluster via the Raft consensus protocol. 
 
-Consider the code in Listing 6.8^[The same code was already shown in Listing 2.21 from Chapter 2], which shows how to use this feature
+Consider the code in Listing 6.8[^10], which shows how to use this feature
 to ensure unique username reservation at the cluster level.
 
 ```{caption="Using compare exchange to validate unique username in a distributed system" .cs}
@@ -1096,3 +1086,15 @@ In the next chapter, we are going to cover how to design your cluster, how to de
 cluster.
 
 [^1]: If you're interested in learning why, I found this answer fascinating: https://www.quora.com/Why-is-a-group-of-crows-called-a-murder
+[^2]: It doesn't make a lot of sense to have a cluster with just two nodes since we'll require both of the nodes to always be up, in most cases. 
+There are certain advanced scenarios where such topology might make sense, and we'll touch on that briefly in Chapter 7.
+[^3]: Rachis is the central shaft of pennaceous feathers.
+[^4]: Of course, we'll be able to create a backup manually. See the discussion about cluster-wide tasks later in this chapter.
+[^5]: I'm on a garden tools naming streak, it appears.
+[^6]: [Of course, it's possible that a client has an _outdated view_ of the topology, but there are mechanisms in place to ensure that clients will figure out that their 
+topology is out of date and refresh it.
+[^7]: This isn't even close to how money transfers really work, of course, but it's a classic example and easy to reason about.
+[^8]: It's not something you'll use for everything, but in most applications there's one or two places where it can be _really_ useful.
+[^9]: Note that different nodes may have different clocks. RavenDB doesn't attempt to compensate for this and will use 
+the latest timestamp from the conflicts in its automatic resolution.
+[^10]: The same code was already shown in Listing 2.21 from Chapter 2.

--- a/Ch07/Ch07.md
+++ b/Ch07/Ch07.md
@@ -73,10 +73,8 @@ make decisions with a majority of only three nodes while the actual size of the 
 > We've talked extensively about clusters being down. Actually, we've spent more time discussing it than the time most clusters spend _being_ down. A cluster being down means database operations continue
 > normally but we can't perform any cluster operations. And what are all those cluster operations?
 >
-> Basically, they're anything that requires us to coordinate between multiple nodes. A non-exhaustive list of these^[The full list can be found in the online
-> documentation] includes creating and deleting databases, creating and deleting indexes, handling subscriptions and ETL processes and completing a 
-> backup.^[Backups _will_ happen on their regular schedule when the cluster is down, but they'll fail to be reported to the cluster and may run again after the cluster has
-> recovered.]
+> Basically, they're anything that requires us to coordinate between multiple nodes. A non-exhaustive list of these[^1] includes creating and deleting databases, creating and deleting indexes, handling subscriptions and ETL processes and completing a 
+> backup.[^2]
 >
 > In all these cases, the operations need a majority in the cluster to process. The underlying logic behind all these operations is that they
 > aren't generally user-facing. So even in the event of a cluster going down, you'll be able to continue serving requests and operate normally, as far as the external
@@ -100,8 +98,7 @@ multiple data centers? And what about when you have geo-distributed data centers
 Because there are so many possible deployment options, I'm going to use AWS as the canonical example, simply because there's so much information about it. You should be able to adapt the advice here to your needs easily enough, even if you aren't using AWS.
 
 Inside the same availability zone (same data center) in Amazon, you can expect ping times of less than a millisecond. Between two availability zones in the same region (separate
-data centers^[Note: this assumes the connection between those data centers doesn't go over the public internet but rather dedicated lines. If the connection between
-the data centers is over the public internet, expect higher latency and more variance in the timings.] that are very close by), you'll typically see ping times 
+data centers[^3] that are very close by), you'll typically see ping times 
 that are in the single-digit millisecond range. 
 
 Each node in the RavenDB cluster expects to get a heartbeat from the leader every 300 milliseconds (that is the default configuration). When running in the same data
@@ -119,7 +116,7 @@ However, what happens when we start talking about geo-distributed data centers? 
 
 Table: A few AWS data centers and their locations
 
-Ping times^[The ping times between these data centers were taken from [cloudping.co](https://www.cloudping.co/).] between these data centers are quite
+Ping times[^4] between these data centers are quite
 different. For example, N. Virginia to Ohio is 30 milliseconds, and N. Virginia to N. California is already at around 70 milliseconds. N. California to London is twice that at 140 milliseconds,
 and Singapore to N. Virginia clocks in at 260 milliseconds.
 
@@ -231,17 +228,13 @@ nodes don't know (or care) that this particular replication target isn't in thei
 replication features, including waiting for offsite replication to occur or ensure distributed transaction boundaries, across disparate geo-distributed clusters.
 
 External replication between two clusters will detect conflicts in editing the same documents in separate clusters and will resolve those conflicts according to each cluster
-conflict resolution policy.^[The conflict resolution will then flow to the other cluster as well, so it's _highly_ recommended that you have the same policy
-configuration on both clusters &mdash; that is, unless you have a specific reason not to, such as one-way replication or a meaningful difference in the tasks that the different
-clusters perform in your system.]
+conflict resolution policy.[^5]
 Figure 7.2 shows the result of a cluster that has defined several external replications from the cluster, for various purposes.
 
 ![Several external replication tasks and their responsible nodes](./Ch07/img02.png)
 
 The responsible node portion has been emphasized in Figure 7.2; you can see the node tag that is responsible for keeping each replication
-target up to date. You can also see that the cluster has assigned each external replication task to a separate node.^[The cluster will make that determination
-on its own, and it may not always perfectly distribute the work among the nodes in this fashion. Overall, however, the work will be distributed among all the
-nodes to create a rough equality of work]. 
+target up to date. You can also see that the cluster has assigned each external replication task to a separate node.[^6]. 
 
 We haven't discussed it yet, but that's one of the more important roles of the cluster: deciding what work goes where. Read more about that in section 7.3.
 
@@ -306,8 +299,7 @@ for making all those separate pieces cooperate seamlessly in the face of error c
 
 ### The ever-watching supervisor
 
-The cluster is continuously measuring the health of each of its nodes, using a component known as the supervisor.^[I always imagine it in bright neon green
-tights and a cape, flying around and spouting cliches as it keeps everything in order.] The supervisor will detect any errors in the cluster, react to a failed node
+The cluster is continuously measuring the health of each of its nodes, using a component known as the supervisor.[^7] The supervisor will detect any errors in the cluster, react to a failed node
 by reassigning work and, in general, keep everything running.
 
 This is important enough to mention here and not in the operations portion of the book because the supervisor also gives you a wealth of information about the 
@@ -357,7 +349,7 @@ to the database completely.
 > **Keep calm and serve requests**
 >
 > You might have noticed that the scenario requiring us to rehabilitate a node in rehab is most easily explained via an operator error. Though rare, such things
-> happen on a fairly regular basis. About a quarter of production failures^[https://journal.uptimeinstitute.com/data-center-outages-incidents-industry-transparency/ ]
+> happen on a fairly regular basis. About a quarter of production failures[^8]
 > are the result of human error.
 > 
 > One of the primary goals of RavenDB is that the database should always be up and responding. That means we do automatic failover on the client and will
@@ -468,5 +460,19 @@ in the ["Production Deployments"](#production-deployments) chapter.
 Beyond just setting up a cluster, you also need to know how to monitor and manage your systems. That's covered in Chapter 16, which is dedicated to that topic. We'll also talk a bit more about the implementation details that I intentionally skipped here. Your
 operations team needs to understand what's going on, exactly. This chapter was about the overall concept.
 
-In the next chapter, we'll talk about how we can integrate with other systems in your organization, and we'll introduce the ETL concept^[Extract, transform, load], which allows
+In the next chapter, we'll talk about how we can integrate with other systems in your organization, and we'll introduce the ETL concept[^9], which allows
 RavenDB to write data to external sources automatically.
+
+[^1]: The full list can be found in the online  documentation.
+[^2]: Backups _will_ happen on their regular schedule when the cluster is down, but they'll fail to be reported to the cluster and may run again after the cluster has recovered.
+[^3]: Note: this assumes the connection between those data centers doesn't go over the public internet but rather dedicated lines. If the connection between
+the data centers is over the public internet, expect higher latency and more variance in the timings.
+[^4]: The ping times between these data centers were taken from [cloudping.co](https://www.cloudping.co/).
+[^5]: The conflict resolution will then flow to the other cluster as well, so it's _highly_ recommended that you have the same policy
+configuration on both clusters &mdash; that is, unless you have a specific reason not to, such as one-way replication or a meaningful difference in the tasks that the different
+clusters perform in your system.
+[^6]: The cluster will make that determination on its own, and it may not always perfectly distribute the work among the nodes in this fashion. Overall, however, 
+the work will be distributed among all the nodes to create a rough equality of work.
+[^7]: I always imagine it in bright neon green tights and a cape, flying around and spouting cliches as it keeps everything in order.
+[^8]: https://journal.uptimeinstitute.com/data-center-outages-incidents-industry-transparency/ .
+[^9]: Extract, transform, load.

--- a/Ch08/Ch08.md
+++ b/Ch08/Ch08.md
@@ -8,7 +8,7 @@ in the same cluster, either as part of the same database group or between differ
 because you just set up the replication and RavenDB takes care of everything else. But there are other modes for distributing data in your systems.
 
 External Replication assumes that you have another RavenDB instance and that you want to replicate _everything_ to it. When replicating information, that's what you
-want, but we also need to be able to share only part of the data. ETL^[Extract, transform, load] is the process by which we take data that resides in RavenDB
+want, but we also need to be able to share only part of the data. ETL[^1] is the process by which we take data that resides in RavenDB
 and push it to an external source, potentially transforming it along the way. That external source can be another RavenDB instance or a relational database. 
 
 Consider a microservice architecture and a "customer benefits service." This service decides what kind of benefits the customer has. It can be anything
@@ -16,8 +16,7 @@ from free shipping to a discount on every third jug of milk. And the logic can b
 trying to compute airline miles. Regardless of how the customer benefits service works, it needs to let other parts of the system know about the 
 benefits that this customer has. The shipping service, the help desk service and many others need to have that information. 
 
-At the same time, we _really_ don't want them to poke around in the customer benefits database (or worse, have a shared database for everything).^[Doing
-so is a great way to ensure that you'll have all the costs of a microservice architecture with none of the benefits.] We could design an API between the 
+At the same time, we _really_ don't want them to poke around in the customer benefits database (or worse, have a shared database for everything).[^2] We could design an API between the 
 systems, but then the shipping service would be dependent on the customer benefits service always being up. A better solution is to define an ETL process between
 the two services and have the customer benefits service publish updates for the shipping service to consume. Those updates are part of the public contract of
 those services, mind you. You shouldn't just copy the data between the databases.
@@ -308,7 +307,7 @@ we can.
 
 That is the worst case, but we can usually do better. An ETL process is an ongoing task in the cluster, and that means that while
 the task is assigned to a single node, the cluster as a whole is still responsible for it. If the node that was assigned to the ETL process is down for
-whatever reason, the cluster will move the task assignment^[Assuming that your license allows dynamic task distribution, that is.] to another node, and 
+whatever reason, the cluster will move the task assignment[^3] to another node, and 
 the ETL process will proceed from there.
 
 Being robust on just the sender side is all well and good, but we're also robust on the receiving end. Part of defining the RavenDB connection string
@@ -573,3 +572,7 @@ the grand architecture of your system.
 
 In the next part of the book, we're going to start on an exciting topic: queries and indexes in RavenDB. This has been a long time coming, and I'm almost
 more excited than you are at this point.
+
+[^1]: Extract, transform, load.
+[^2]: Doing so is a great way to ensure that you'll have all the costs of a microservice architecture with none of the benefits.
+[^3]: Assuming that your license allows dynamic task distribution, that is.

--- a/Ch09/Ch09.md
+++ b/Ch09/Ch09.md
@@ -3,8 +3,7 @@
 
 [Querying in RavenDB]:(#query-engine)
 
-Queries in RavenDB use a SQL-like language called "RavenDB Query Language,"^[Aren't you surprised?] henceforth known as RQL.^[Pronounced
-"Rachel," like my wife, and because it's funny.]
+Queries in RavenDB use a SQL-like language called "RavenDB Query Language,"[^1] henceforth known as RQL.[^2]
 
 You've already run into the RavenDB Query Language when using subscriptions, even if I didn't explicitly call it out as such. Both
 subscriptions and queries use RQL, although there are a few differences between the two supported options. The idea with 
@@ -1003,9 +1002,7 @@ all the _other_ orders (by other customers) to complete indexing before you get 
 > you're reading the latest information.
 >
 > The part about slowing the write is not so hot, but the part about getting the latest information is surely what you want, right? Well, that depends
-> on what this costs. A study of relational databases^["[OLTP – Through the Looking Glass, and What We Found 
-> There](https://scholar.google.com/scholar?cluster=12931776946707721868) " by Stavros Harizopoulos, Daniel 
-> Abadi, Samuel Madden, Michael Stonebraker.] shows that they spend over 30% of their time just managing locks of various kinds. This is a 
+> on what this costs. A study of relational databases[^3] shows that they spend over 30% of their time just managing locks of various kinds. This is a 
 > truly stupendous amount of effort to spend on managing locks, and a large part of that is to ensure you get the properly consistent 
 > guarantees. 
 >
@@ -1059,3 +1056,9 @@ that, by default, writes will complete without waiting for indexes, but there ar
 during the read (although that is not recommended).
 
 In the next chapter, we're going to talk about customer indexes (called static indexes in RavenDB) that you'll define. We'll also cover what kind of fun we can have with them and what features and queries they enable.
+
+[^1]: Aren't you surprised?
+[^2]: Pronounced "Rachel," like my wife, and because it's funny.
+[^3]: "[OLTP – Through the Looking Glass, and What We Found There](https://scholar.google.com/scholar?cluster=12931776946707721868) " by Stavros Harizopoulos, Daniel 
+Abadi, Samuel Madden, Michael Stonebraker.
+

--- a/Ch10/Ch10.md
+++ b/Ch10/Ch10.md
@@ -735,7 +735,7 @@ A term vector for the paragraph will contain a list of all unique words and how 
 
 With all of the preparations complete, we can now actually make our first "more like this" query, which is shown in Listing 10.19.
 
-```{caption="Finding similar orders to \'orders/535-A\' based on products ordered and the city and country it was shipped to"}
+```{caption="Finding similar orders to 'orders/535-A' based on products ordered and the city and country it was shipped to"}
 from index 'Orders/Search' 
 where morelikethis(id() = 'orders/535-A')
 ```
@@ -842,7 +842,7 @@ select
 In Listing 10.22, we're querying over the same facets, but we're now also limiting it to just particular suppliers. The output of the `Price` facet
 will change, as shown in Listing 10.23.
 
-```{caption="`Price` facet output from the query in Listing 10.22" .json}
+```{caption="'Price' facet output from the query in Listing 10.22" .json}
 {
     "Name": "Price",
     "Values": [

--- a/Ch10/Ch10.md
+++ b/Ch10/Ch10.md
@@ -735,7 +735,7 @@ A term vector for the paragraph will contain a list of all unique words and how 
 
 With all of the preparations complete, we can now actually make our first "more like this" query, which is shown in Listing 10.19.
 
-```{caption="Finding similar orders to `orders/535-A` based on products ordered and the city and country it was shipped to"}
+```{caption="Finding similar orders to \'orders/535-A\' based on products ordered and the city and country it was shipped to"}
 from index 'Orders/Search' 
 where morelikethis(id() = 'orders/535-A')
 ```

--- a/Ch10/Ch10.md
+++ b/Ch10/Ch10.md
@@ -1140,7 +1140,7 @@ and have that done regardless of the shape of the data we index.
 We can do that in RavenDB quite easily with a bit of pre-planning. Let's look at Listing 10.30, showing the `Employees/DynamicFields`
 index and how RavenDB allows us to index dynamic fields. 
 
-```{caption="`Employees/DynamicFields` index, using dynamic fields" .cs}
+```{caption="'Employees/DynamicFields' index, using dynamic fields" .cs}
 from e in docs.Employees
 select new 
 {

--- a/Ch10/Ch10.md
+++ b/Ch10/Ch10.md
@@ -315,8 +315,7 @@ and query on it.
 We can also _filter_ data out during indexing. The indexing function takes a collection of documents and returns a collection of index 
 entries. It can also return _no_ index entries, in which case the document will not be indexed. This can be done using a `where` in the 
 Linq expression that composes the index definition. Listing 10.10 shows an example of filtering out employees without a manager for the
-"Employees/ByManager" index.^[The general recommendation is that you have a single index per collection with all the fields that you 
-want to search defined on that index. It's better to have fewer and bigger indexes than many smaller indexes.]
+"Employees/ByManager" index.[^1]
 
 ```{caption="Filtering documents during indexing" .cs}
 from employee in docs.Employees
@@ -556,7 +555,7 @@ The `search()` method accepts the query string you're looking for and passes it 
 the analyzer returned with the terms already in the index, and if there's a match on any of them, it's considered to be a match for the query. 
 There's also the ranking of the results to take into account. The more terms that are matched by a particular document from the query, the higher it will
 be in the results. This is affected by such things as the term frequency, the size of the document and a lot of other things that I'm not going to
-cover but are quite interesting to read about.^[See the _Lucene in Action_ and _Managing Gigabytes_ books, recommended in the previous chapter.]
+cover but are quite interesting to read about.[^2]
 
 What happens when we're making a query on a full text field (one with an analyzer defined) without using `search()`? Let's see:
 
@@ -657,7 +656,7 @@ select suggest(Query, "Martin")
 We're asking RavenDB, "What could the user have meant by 'Martin' in the `Query` field?" RavenDB will try to look at the data in the index for this
 field and infer the intent of the user. If you care to know the details, RavenDB breaks the terms into pieces during the indexing process and scrambles
 them to simulate common errors. Those all go into an index that's used during query. This does increase the cost of indexing, but the cost of 
-querying suggestions is typically very low. I wouldn't suggest^[Pun intended.] applying this globally, but for user-facing searches, the dataset is typically pretty stable, so that works out great.
+querying suggestions is typically very low. I wouldn't suggest[^3] applying this globally, but for user-facing searches, the dataset is typically pretty stable, so that works out great.
 
 The result of the query in Listing 10.16 can be seen in Figure 10.7. 
 
@@ -1155,8 +1154,7 @@ select new
 
 There are several things going on with the `Employees/DynamicFields` index in Listing 10.30. First, we used the `_` variable name as 
 an index output to indicate that this index is using dynamic field indexes. (Otherwise, RavenDB will error with an invalid field name
-when you query.)^[We can only use `_` once in an index output, and the name of the field doesn't matter when you use `CreateField`, so
-we typically just use `__`, `___`, etc. for the dynamic field names.] You can see that you can mix and match dynamic index names with
+when you query.)[^4] You can see that you can mix and match dynamic index names with
 static field names. RavenDB doesn't mind, it just works. 
 
 We also used the `CreateField` method twice. The first time, we used it to index all the fields inside the `Address` object. 
@@ -1187,7 +1185,7 @@ end up costing time and disk space for no return.
 
 ### Summary
 
-We started this chapter by discussing _what_ indexes are in RavenDB. We saw that, like an onion,^[Or an ogre.] indexes come in layers.
+We started this chapter by discussing _what_ indexes are in RavenDB. We saw that, like an onion,[^5] indexes come in layers.
 There's the index definition, specifying what and how we should index, the index on disk and the actual indexing process. We started
 working with indexes explicitly by defining indexes using `Linq` expressions.
 Such expressions give us the ability to select the fields (and computed values) that we want to be able to index. 
@@ -1232,3 +1230,11 @@ indexed documents. This is useful for user generated data and when you're workin
 the data in any way you want. 
 
 In the next chapter, we'll look into RavenDB's MapReduce indexes, what they can do for you and how they actually work.
+
+[^1]: The general recommendation is that you have a single index per collection with all the fields that you 
+want to search defined on that index. It's better to have fewer and bigger indexes than many smaller indexes.
+[^2]: See the _Lucene in Action_ and _Managing Gigabytes_ books, recommended in the previous chapter.
+[^3]: Pun intended.
+[^4]: We can only use `_` once in an index output, and the name of the field doesn't matter when you use `CreateField`, so
+we typically just use `__`, `___`, etc. for the dynamic field names.
+[^5]: Or an ogre.

--- a/Ch10/Ch10.md
+++ b/Ch10/Ch10.md
@@ -1140,7 +1140,7 @@ and have that done regardless of the shape of the data we index.
 We can do that in RavenDB quite easily with a bit of pre-planning. Let's look at Listing 10.30, showing the `Employees/DynamicFields`
 index and how RavenDB allows us to index dynamic fields. 
 
-```{caption="'Employees/DynamicFields' index, using dynamic fields" .cs}
+```{caption="`Employees/DynamicFields` index, using dynamic fields" .cs}
 from e in docs.Employees
 select new 
 {

--- a/Ch11/Ch11.md
+++ b/Ch11/Ch11.md
@@ -865,7 +865,7 @@ That's a great thing since it simplifies dynamic queries. But it also means that
 aggregation on a very large result set, it's going to take time to process. A MapReduce on the same (or much larger) amount
 of data will be much faster at querying time, but it's limited in the amount of flexibility it allows for each query.
 
-Combining MapReduce and facets to handle this is a great way to reduce^[Pun very much intended here.] the amount of data the
+Combining MapReduce and facets to handle this is a great way to reduce[^1] the amount of data the
 facets need to go through. It's easiest to consider this kind of approach as feeding the facets baby food, already pre-chewed. 
 That dramatically cuts down the amount of effort required to get the final result.
 
@@ -1020,3 +1020,5 @@ that are available to you.
 
 In the next chapter, we'll switch gears a bit and move to a more practical mindset, talking about how to utilize and work with
 indexes in your applications.
+
+[^1]: Pun very much intended here.

--- a/Ch11/Ch11.md
+++ b/Ch11/Ch11.md
@@ -718,7 +718,7 @@ Take a few minutes to look at Listing 11.13. There's a lot of stuff going on the
 `Companies`, `Suppliers` and `Employees`. And for each, we output a count for the type of the document we're mapping, as well as the relevant `City`. Finally, on the reduce, we simply group by `City` and then sum up all the results 
 from all the intermediate steps to get the final tally. Listing 11.14 shows the output from this index for London.
 
-```{caption="Output of the `Cities/Details` index for London"}
+```{caption="Output of the 'Cities/Details' index for London"}
 {
     "City": "London",
     "Companies": 6,

--- a/Ch11/Ch11.md
+++ b/Ch11/Ch11.md
@@ -736,7 +736,7 @@ function: `OrderTotal = g.Sum(x => x.OrderTotal)`. The first step is required be
 must have the same output. The second is required to actually sum up the information we'll shortly add. Now click on the 
 `Add map` button on the index edit page and add the map shown in Listing 11.15.
 
-```{caption="Adding total order per city to the `Cities/Details` index" .cs}
+```{caption="Adding total order per city to the 'Cities/Details' index" .cs}
 from o in docs.Orders
 select new
 {

--- a/Ch11/Ch11.md
+++ b/Ch11/Ch11.md
@@ -884,7 +884,7 @@ interface and the results we want to see.
 The simplest way to be able to answer this query is to use `LoadDocument` in the map phase of the index. You can see how 
 this is done in Listing 11.18.
 
-```{caption="MapReduce index using `LoadDocument` can pull data from related documents" .cs}
+```{caption="MapReduce index using 'LoadDocument' can pull data from related documents" .cs}
 //map
 from o in docs.Orders
 from l in o.Lines

--- a/Ch11/Ch11.md
+++ b/Ch11/Ch11.md
@@ -884,7 +884,7 @@ interface and the results we want to see.
 The simplest way to be able to answer this query is to use `LoadDocument` in the map phase of the index. You can see how 
 this is done in Listing 11.18.
 
-```{caption="MapReduce index using 'LoadDocument' can pull data from related documents" .cs}
+```{caption="MapReduce index using `LoadDocument` can pull data from related documents" .cs}
 //map
 from o in docs.Orders
 from l in o.Lines

--- a/Ch12/Ch12.md
+++ b/Ch12/Ch12.md
@@ -1097,7 +1097,7 @@ and `null` concatenated with a string is the string.
 
 Some kinds of errors don't really let us recover. Consider the code in Listing 12.22. The index itself isn't very interesting, but we have an `int.Parse` call there on the `PostalCode` property.
 
-```{caption="Parsing UK `PostalCode` as `int` will throw an exception" .cs}
+```{caption="Parsing UK 'PostalCode' as 'int' will throw an exception" .cs}
 public class Employees_PostalCode
   : AbstractIndexCreationTask<Employee>
 {

--- a/Ch12/Ch12.md
+++ b/Ch12/Ch12.md
@@ -1063,7 +1063,7 @@ Sometimes, your index runs into an error. RavenDB actually goes to great lengths
 inside the index will propagate nulls transitively. In other words, you can write the index shown in Listing 12.21
 and you won't get a `NullReferenceException`. 
 
-```{caption="Accessing a null `manager` instance will not throw an exception" .cs}
+```{caption="Accessing a null 'manager' instance will not throw an exception" .cs}
 public class Employees_Managers
   : AbstractIndexCreationTask<Employee>
 {

--- a/Ch12/Ch12.md
+++ b/Ch12/Ch12.md
@@ -610,7 +610,7 @@ API. This is because you'll typically compose queries programmatically using thi
 to do complex projections from the query.
 This is easy to do, as you can see in Listing 12.18.
 
-```{caption="Using a custom projection with the `DocumentQuery` API" .cs}
+```{caption="Using a custom projection with the 'DocumentQuery' API" .cs}
 List<SearchResult> results = 
     session.Advanced.DocumentQuery<People_Search.Result, People_Search>()
     .WhereStartsWith(x => x.Name, "Mar")

--- a/Ch12/Ch12.md
+++ b/Ch12/Ch12.md
@@ -1097,7 +1097,7 @@ and `null` concatenated with a string is the string.
 
 Some kinds of errors don't really let us recover. Consider the code in Listing 12.22. The index itself isn't very interesting, but we have an `int.Parse` call there on the `PostalCode` property.
 
-```{caption="Parsing UK 'PostalCode' as 'int' will throw an exception" .cs}
+```{caption="Parsing UK `PostalCode` as `int` will throw an exception" .cs}
 public class Employees_PostalCode
   : AbstractIndexCreationTask<Employee>
 {

--- a/Ch13/Ch13.md
+++ b/Ch13/Ch13.md
@@ -30,9 +30,7 @@ being usable if it is stolen.
 > **Running RavenDB in an unsecured mode**
 >
 > You might find this surprising, but it is very common to run RavenDB with no security whatsoever. This typically happens when RavenDB is running on a developer machine. By default, this mode is only allowed as long as RavenDB is listening to
-> either `127.0.0.1`, `::1` or `localhost`. In other words, as long as RavenDB is not listening on the network.^[RavenDB will 
-> _refuse_ to run in this mode while listening to other IPs unless you explicitly tell it that you are fine with an unsecured 
-> setup.]
+> either `127.0.0.1`, `::1` or `localhost`. In other words, as long as RavenDB is not listening on the network.[^1]
 >
 > In such a mode, _none_ of the security features of RavenDB are accessible. You can neither authenticate users (anyone listening on
 > the network would be able to hijack the connection, after all) nor create or use encrypted databases (anyone can
@@ -53,9 +51,7 @@ information you already have than risk missing something critical. Securing a Ra
 2. Allow the server to verify that the client is valid and decide what access the client should have.
 3. Prevent anyone else from eavesdropping on the communication between server and client, hijacking the client credentials, etc.
 
-RavenDB is not the first to have this set of requirements. Instead of rolling our system^[Roll your own is usually a _bad_
-idea with security practices.], RavenDB uses the TLS 1.2 protocol.^[TLS - Transport Level Security, the successor to SSL and what is actually 
-used when you are using HTTPS] You might not be familiar with the term; a more common use name for
+RavenDB is not the first to have this set of requirements. Instead of rolling our system[^2], RavenDB uses the TLS 1.2 protocol.[^3] You might not be familiar with the term; a more common use name for
 this is HTTPS. RavenDB uses TLS 1.2 in the following ways:
 
 * The database server identifies itself to clients with a `X509` certificate.
@@ -216,9 +212,7 @@ You should see a screen similar to the one in Figure 13.2.
 > certificates.
 > 
 > These domains looks like `<name>.development.run` or `<name>.ravendb.community`.
-> You can provide any `<name>` you want as long as it hasn't been taken by someone else.^[The exact domain you'll get depends on the
-> the license you are using. If you're using a development license, you'll get `development.run`; if you're are using a 
-> community license, you'll get `ravendb.community`; and if you're using a commercial license, you'll get `ravendb.run`.] 
+> You can provide any `<name>` you want as long as it hasn't been taken by someone else.[^4] 
 >
 > Names are provided on a first come, first served basis, and once they have been given to a user, they are associated with that
 > user permanently. 
@@ -311,8 +305,7 @@ certificate.
 Once you've installed the admin client certificate, you can click on the `Restart Server` button at the end of the setup screen. The browser should then redirect you
 to the RavenDB management Studio. At this point in the process, you are actually running a secured server, which means you need to authenticate 
 yourself to the server. This is the purpose of installing the admin certificate. You should get a dialog similar to the one shown
-in Figure 13.6 and you should select the appropriate certificate (if you have more than one).^[If you make a mistake and choose the wrong certificate (or cancel the dialog), you'll need to close Chrome and restart it to make it forget this 
-decision. Creating an incognito window also works, and might be easier.]
+in Figure 13.6 and you should select the appropriate certificate (if you have more than one).[^5]
 
 ![Chrome certificate selection dialog for your RavenDB instance](./Ch13/img06.png)
 
@@ -343,7 +336,7 @@ This is it: you now have a cluster of three nodes. You have a valid certificate 
 access to the cluster. Authentication to the cluster is done via the generated admin client certificate (you'll learn more about
 authentication in RavenDB later in this chapter). The setup process has also updated the DNS system for your cluster, so you can put
 `https://a.raven.development.run` to go to node `A`, or `https://b.raven.development.run`
-to go to node `B`, etc.^[Your URLs will obviously be a bit different.]
+to go to node `B`, etc.[^6]
 
 > **Updating the certificate over time**
 >
@@ -430,8 +423,7 @@ define certificates through an API, so this is easily automated.) You can see wh
 
 ![Client certificate screen in the RavenDB Studio](./Ch13/img09.png)
 
-In order for RavenDB to accept a client certificate as valid, it _must_ be registered with the cluster.^[The one exception to this rule is that the server's own certificate is
-always acceptable as a client certificate.] Note that as long as the certificate has been registered with RavenDB, RavenDB does not validate the 
+In order for RavenDB to accept a client certificate as valid, it _must_ be registered with the cluster.[^8] Note that as long as the certificate has been registered with RavenDB, RavenDB does not validate the 
 certificate aside from verifying that it has not expired.
 
 To be more specific: RavenDB does not check the certificate chain of trust or the validity period of the certificate that signed the 
@@ -752,7 +744,7 @@ authorization in RavenDB.
 Security is a _big_ topic, one that needs to be taken seriously and handled with care. Recognizing this, we ran
 RavenDB through an external security audit in January 2018 and made 
 [the resulting report](https://ravendb.net/Content/pdf/ravendb-final-security-report-jan-12-2017.pdf) 
-public.^[You can get the security report at: https://tinyurl.com/rvn-sec-rpt]
+public.[^8]
 
 We started this chapter with a brief review of the state of the network under the baseline assumption that the
 network is _hostile_ and we should take explicit steps to protect ourselves, our systems and our data. RavenDB 
@@ -805,3 +797,15 @@ connections and the security clearance that these connections are granted.
 In this chapter, we talked about security in transit: encrypting data as it goes through the network, authenticating who we are talking to and authorizing that users and systems are allowed to perform the operations they've requested.
 In the next chapter, we are going to talk about encryption at rest: how we can ensure that our data is safe, even
 if our hard disk is not.
+
+[^1]: RavenDB will _refuse_ to run in this mode while listening to other IPs unless you explicitly tell it that you are fine with an unsecured setup.
+[^2]: Roll your own is usually a _bad_ idea with security practices.
+[^3]: TLS - Transport Level Security, the successor to SSL and what is actually used when you are using HTTPS.
+[^4]: The exact domain you'll get depends on the the license you are using. If you're using a development license, you'll get `development.run`; if you're are using a 
+community license, you'll get `ravendb.community`; and if you're using a commercial license, you'll get `ravendb.run`.
+[^5]: If you make a mistake and choose the wrong certificate (or cancel the dialog), you'll need to close Chrome and restart it to make it forget this 
+decision. Creating an incognito window also works, and might be easier.
+[^6]: Your URLs will obviously be a bit different.
+[^7]: The one exception to this rule is that the server's own certificate is always acceptable as a client certificate.
+[^8]: You can get the security report at: https://tinyurl.com/rvn-sec-rpt
+

--- a/Ch13/Ch13.md
+++ b/Ch13/Ch13.md
@@ -423,7 +423,7 @@ define certificates through an API, so this is easily automated.) You can see wh
 
 ![Client certificate screen in the RavenDB Studio](./Ch13/img09.png)
 
-In order for RavenDB to accept a client certificate as valid, it _must_ be registered with the cluster.[^8] Note that as long as the certificate has been registered with RavenDB, RavenDB does not validate the 
+In order for RavenDB to accept a client certificate as valid, it _must_ be registered with the cluster.[^7] Note that as long as the certificate has been registered with RavenDB, RavenDB does not validate the 
 certificate aside from verifying that it has not expired.
 
 To be more specific: RavenDB does not check the certificate chain of trust or the validity period of the certificate that signed the 

--- a/Ch14/Ch14.md
+++ b/Ch14/Ch14.md
@@ -159,11 +159,7 @@ uses encryption to protect your data. You can safely skip this section if you'd 
 very little impact on using and operating RavenDB.
 
 Internally, RavenDB holds your data inside a data file (usually called `Raven.voron`) that's 
-memory-mapped to the RavenDB process. We also use temporary files^[These files are 
-also memory-mapped, but they aren't persistent, as far as RavenDB is concerned.
-Instead, we are using memory-mapped files to avoid using too much private memory and give the 
-operating system well-known backing store for this temporary memory. It also allows RavenDB to 
-have fine-grained control over the memory usage required by the storage requirements.], which are
+memory-mapped to the RavenDB process. We also use temporary files[^1], which are
 typically found in the Temp directory and have names such as: 
 `Temp/scratch.0000000000.buffers` and `Temp/compression.0000000000.buffers`. 
 There are also the write-ahead journals, which 
@@ -181,8 +177,7 @@ The write-ahead journal is a set of files (`Journals/0000000000000000001.journal
 guarantees. Each journal file is allocated in advance (typically 256 MB at a time), and a new 
 transaction is written to the file whenever it's committed. Indeed, a transaction cannot be 
 considered committed unless it's been successfully written to the journal 
-file.^[RavenDB uses direct and unbuffered I/O to write to the disk, ensuring 
-that writes are persistent, skipping the caches in the middle.] 
+file.[^2] 
 
 A journal file is a set of consecutive transactions. When RavenDB opens a database, it will read 
 the journal file, find all the transactions that haven't yet been synced to disk and apply them to 
@@ -235,9 +230,7 @@ and a 192 bits random nonce.
 The main data file (`Raven.voron`) contains all the data in your database. Unlike the journals, 
 which are written to in a consecutive manner — one transaction at a time — the data file is 
 written to and read from using random I/O. To handle this mode of operations, the data file is 
-split into 8 KB pages^[There are a lot of other reasons why the data is divided into pages,
-and this is how RavenDB works without encryption as well. It just happens that it also plays 
-very nicely into the requirements for using the data while keeping it encrypted.] that can be 
+split into 8 KB pages[^3] that can be 
 treated as independent of one another. If there's a value over 8 KB in size, then the file will
 use as many consecutive pages as needed and will be treated as a single page, as only the first of 
 those pages will have a page header.
@@ -451,7 +444,7 @@ a secure server, it does not require the destination to be an encrypted database
 > better performance and makes specific operational tasks easier (see the discussion on backups later in this chapter).
 
 In addition to external replication, it's common to use ETL processes to extract data out of a 
-RavenDB database. A good example is on a system that stores payment information. Given PCI^[Payment Card Industry.] 
+RavenDB database. A good example is on a system that stores payment information. Given PCI[^4] 
 compliance issues, data must be stored in an encrypted way. But imagine we set up the 
 RavenDB ETL process on a separate database to let us work with the data more easily. In doing 
 so, we removed the sensitive payment details and were effectively left with just the orders 
@@ -464,8 +457,7 @@ secure mode (HTTPS), we don't always have a good way to detect whether your SQL 
 string is itself encrypted. It's therefore the admin's responsibility to ensure that this 
 communication channel is safe from eavesdropping. For that matter, regardless of whether 
 your communication channel is encrypted, admins should be aware of the data flow inside the system, making sure that sensitive 
-information is not sent to an unencrypted store and potentially exposing data that shouldn't be stored in plain text.^[You can force RavenDB to accept 
-ETL tasks that use non encrypted channels using the `AllowEtlOnNonEncryptedChannel` option.]
+information is not sent to an unencrypted store and potentially exposing data that shouldn't be stored in plain text.[^5]
 
 ### Key management
 
@@ -485,8 +477,7 @@ writing this key down, you can just sit back and let run everything normally.
 But this leads to an interesting question: Where is the key stored on our end, and how?
 
 In fact, there isn't a key in the singular sense; there might be more than one. RavenDB uses the 
-following two keys^[Both the database keys and the server master key are local to a node, 
-not shared across the cluster.]:
+following two keys[^6]:
 
 * Database encryption key - a per-database key, used as the master encryption key for the 
   entire database and stored on the server store
@@ -518,9 +509,7 @@ database, we'll hand the encrypted value back to `DPAPI` and get the key in retu
 can then use to open the encrypted database.
 
 This process has the advantage of being pretty seamless and (usually) good enough as a security measure. 
-The disadvantage is that this security is tied to your Windows password.^[In this case,
-the relevant password is for the user account that is running the RavenDB process. That will 
-usually not be a normal user, but a service account.] For example, an admin 
+The disadvantage is that this security is tied to your Windows password.[^7] For example, an admin 
 resetting a password will cause `DPAPI` to fail at decrypting any values encrypted with the old 
 password. (Note that changing your password, which requires entering the current password, is 
 safe in this regard. Only a password reset will lose us access to previously encrypted `DPAPI` 
@@ -686,9 +675,7 @@ RavenDB supports the following forms of backups:
 
 For an encrypted database, it's important to consider what parts of the backup are encrypted, 
 and in what manner. With a Snapshot backup, the entire snapshot is encrypted using the 
-database encryption key. Conceptually, you're getting the raw file from the disk-as is^[Note 
-that this is just a conceptual model. You can't just copy the file out of the way while 
-RavenDB is running and consider this a backup].
+database encryption key. Conceptually, you're getting the raw file from the disk-as is[^8].
 
 As a result, you _must_ have the appropriate encryption key if you ever want to restore the 
 snapshot. Without this key, there's no way to restore the database, access the data or really do 
@@ -767,3 +754,19 @@ the off case that you'll need them.
 
 This chapter also closes our discussion on security inside RavenDB. The next topic on the table 
 is an in-depth dive into operations, deployments and monitoring your production clusters.
+
+[^1]: These files are also memory-mapped, but they aren't persistent, as far as RavenDB is concerned.
+Instead, we are using memory-mapped files to avoid using too much private memory and give the 
+operating system well-known backing store for this temporary memory. It also allows RavenDB to 
+have fine-grained control over the memory usage required by the storage requirements.
+[^2]: RavenDB uses direct and unbuffered I/O to write to the disk, ensuring that writes are persistent, skipping the caches in the middle.
+[^3]: There are a lot of other reasons why the data is divided into pages,
+and this is how RavenDB works without encryption as well. It just happens that it also plays 
+very nicely into the requirements for using the data while keeping it encrypted.
+[^4]: Payment Card Industry.
+[^5]: You can force RavenDB to accept ETL tasks that use non encrypted channels using the `AllowEtlOnNonEncryptedChannel` option.
+[^6]: Both the database keys and the server master key are local to a node, not shared across the cluster.
+[^7]: In this case, the relevant password is for the user account that is running the RavenDB process. That will 
+usually not be a normal user, but a service account.
+[^8]: Note that this is just a conceptual model. You can't just copy the file out of the way while 
+RavenDB is running and consider this a backup.

--- a/Ch15/Ch15.md
+++ b/Ch15/Ch15.md
@@ -482,7 +482,7 @@ node.
 
 Using a database's data directory as the base, RavenDB uses the format shown in Listing 15.1.
 
-```{caption="On disk structure of the `Northwind` database folder in RavenDB"}
+```{caption="On disk structure of the 'Northwind' database folder in RavenDB"}
 *-- Indexes
 | *-- Orders_ByCompany
 | | *-- Journals

--- a/Ch15/Ch15.md
+++ b/Ch15/Ch15.md
@@ -70,9 +70,7 @@ repeating. There are a lot of good materials about how to go about your system's
 point you again to the Release It! book for more details. 
 
 There is an obvious correlation between the load on your system and the resources it consumes to handle this load.
-Figure 15.1 shows a couple of graphs from a production system. This isn't peak load, but it isn't idle either.^[All
-the stats and monitoring details are directly from the RavenDB Studio. We'll go over where they are located and what
-you can deduce from them in the next chapter.] 
+Figure 15.1 shows a couple of graphs from a production system. This isn't peak load, but it isn't idle either.[^1] 
 
 ![Load and resource graphs from the RavenDB dashboard on production system](./Ch15/img01.png)
 
@@ -210,8 +208,7 @@ your environment and needs. These aren't the only options, and you can usually m
 > some (or all) of the nodes, depending on the replication factor for the specific database.
 >
 > RavenDB doesn't split the database data among the various nodes, but replicates _all_ the data in the database
-> to each of the nodes in the database group.^[See Chapters 6 and 7 for full details on how RavenDB clusters 
-> behave.]
+> to each of the nodes in the database group.[^2]
 
 You'll typically use a dedicated database per application, potentially with some data flows (ETL and external 
 replication) between them. These databases are hosted on a single cluster, which simplifies management and operations.
@@ -334,8 +331,7 @@ replicates the data. This is also called active/passive topology.
 ![A primary server replicating to a secondary](./Ch15/img07.png)
 
 With RavenDB, using a two-node cluster is not a good idea. The majority of two is still two, after all, so even a single 
-node failure will make the cluster unavailable.^[Although the _databases_ inside that cluster will 
-continue to be available from the remaining node.] 
+node failure will make the cluster unavailable.[^3] 
 A two-node cluster is sometimes chosen as the selected topology when you want to manually control failover behavior for some reason.
 We'll cover this option in the next section.
 
@@ -599,8 +595,7 @@ failure to connect.
 I want to point out a few of the more common configuration options and their impacts on production deployments. The online documentation has full details on all different options you might want to play with. 
 
 On Linux, the number of open file descriptors can often be a stumbling block. RavenDB doesn't actually use
-that many file descriptors.^[See Listing 15.1 to get a good idea of the number of files RavenDB will 
-typically have open.] However, network connections are also using file descriptors, and under
+that many file descriptors.[^4] However, network connections are also using file descriptors, and under
 load, it's easy to run out of them. You can configure this with `ulimit -n 10000`. 
 
 Another common issue on Linux is wanting to bind to a port that is lower than 1024 (such as 443 for HTTPS).
@@ -659,3 +654,9 @@ operating system.
 
 This chapter is meant to give you a broad overview of deploying RavenDB, and I recommend following it up by going over the 
 detailed instructions in the online documentation. Now that your RavenDB cluster is up and running, you need to know how to maintain it. Next topic: monitoring, troubleshooting and disaster recovery.
+
+[^1]: All the stats and monitoring details are directly from the RavenDB Studio. We'll go over where they are located and what
+you can deduce from them in the next chapter.
+[^2]: See Chapters 6 and 7 for full details on how RavenDB clusters behave.
+[^3]: Although the _databases_ inside that cluster will continue to be available from the remaining node.
+[^4]: See Listing 15.1 to get a good idea of the number of files RavenDB will typically have open.

--- a/Ch15/Ch15.md
+++ b/Ch15/Ch15.md
@@ -482,7 +482,7 @@ node.
 
 Using a database's data directory as the base, RavenDB uses the format shown in Listing 15.1.
 
-```{caption="On disk structure of the 'Northwind' database folder in RavenDB"}
+```{caption="On disk structure of the `Northwind` database folder in RavenDB"}
 *-- Indexes
 | *-- Orders_ByCompany
 | | *-- Journals

--- a/Ch16/Ch16.md
+++ b/Ch16/Ch16.md
@@ -24,7 +24,7 @@ now explore what kind of hooks are provided for you to do just that.
 
 ### Ongoing monitoring
 
-The most obvious monitoring option is to use SNMP.^[Simple Network Management Protocol]
+The most obvious monitoring option is to use SNMP.[^1]
 To configure SNMP in RavenDB you'll need to set it up in the way shown in Listing 16.1.
 
 ```{caption="Setting up SNMP using the settings.json configuration file" .json}
@@ -487,7 +487,7 @@ space is needed, until 1 GB is reached. After that, the data file grows by 1 GB 
 You can see how the space is used in a particular item by clicking on it in the Studio, where the breakdown is shown between journals and data for that storage environment. Journals are used whenever a transaction is committed. These files are where RavenDB writes all the changes that happen in a transaction, ensuring that the data is stored in a persistent way and that the hot path of I/O is sequential writes, which is the fastest option.
 
 Journal files are also pre-allocated in terms of space (starting at 64 KB and doubling in size to a max of 
-256 MB^[All these sizes, as well as the max size of database's growth are configurable, of course.]). Whenever RavenDB is
+256 MB[^2]). Whenever RavenDB is
 finished using a particular journal file, it will not delete it, but instead reuse it, as needed. This saves the amount of on-disk
 space allocated to the journals. RavenDB does rename the files to maintain consistent numbering, but the reuse of journals
 makes sure that the file system allocation is otherwise unchanged.
@@ -593,8 +593,7 @@ The common network issues with RavenDB include:
 * TLS downgrade - Some appliances can only accept certain versions of SSL/TLS connections. RavenDB _requires_ you to use TLS 1.2 to connect and will show an error if a connection is attempted using TLS 1.0 or 1.1. 
 
 Troubleshooting issues on the network usually means using low-level tools, such as packet inspectors likes `WireShark`. While I'm not 
-going to go into the details of such tools, I want to point out that in many cases — especially for resolving issues in TLS/SSL connections — using `openssl s_client`^[Full documentation for this feature can be found in the 
-[OpenSSL Cookbook.](https://www.feistyduck.com/library/openssl-cookbook/online/ch-testing-with-openssl.html).] 
+going to go into the details of such tools, I want to point out that in many cases — especially for resolving issues in TLS/SSL connections — using `openssl s_client`[^3]
 can be much easier. The full command is:  
 `$ openssl s_client -connect a.oren.ravendb.run:443 \  
     -cert client.pem -key client.pem`.
@@ -603,7 +602,7 @@ The output of this command can tell you quite a lot about the connection. In par
 
 #### Internal, external and multiple IPs
 
-When you run on your own hardware, the situation is pretty simple: Your server has _one_ IP address to listen to and that clients will use to talk to it. But when you run in the cloud, things get more complicated. Your server has both an internal IP to listen to (such as `172.31.25.240`) and a public IP (such as `52.9.72.38`)^[These are real internal and external IPs from one of our AWS machines.].
+When you run on your own hardware, the situation is pretty simple: Your server has _one_ IP address to listen to and that clients will use to talk to it. But when you run in the cloud, things get more complicated. Your server has both an internal IP to listen to (such as `172.31.25.240`) and a public IP (such as `52.9.72.38`)[^4].
 
 The server can't actually bind to `52.9.72.38`, because it isn't directly exposed to the network. Instead, any 
 connection to this IP will be routed to the server by the cloud's network appliances. This leads to an interesting
@@ -703,8 +702,7 @@ and the user who is running the RavenDB process have access to this named pipe a
 Hardware does break and disks do fail — eventually, entropy will take us all. Yet I'll assume that you can get over the depressing reality of the previous statement and actually want to do something when such things happen. The scenario we'll deal with in this case is a bad sector, hardware failure or something similar that resulted in data corruption of the RavenDB on-disk files.
 
 RavenDB uses hashing to ensure that the data has been successfully written to the disk. This allows RavenDB to detect if
-there have been unexpected changes to the data.^[By default the hash function used is XXHash64, which is non-cryptographic. It doesn't provide any level of authentication. A malicious user that can modify RavenDB's on disk files can update the data and the hash without RavenDB ever knowing. 
-When using an encrypted database, RavenDB uses cryptographic authentication to ensure that the data was modified only by someone who holds the secret encryption key.] In this way, data corruption can be detected and handled early on — before it has the chance to spread. RavenDB will mark a database with such an error as corrupted and shut it down.
+there have been unexpected changes to the data.[^5] In this way, data corruption can be detected and handled early on — before it has the chance to spread. RavenDB will mark a database with such an error as corrupted and shut it down.
 
 If you're running in a cluster, the usual — and easiest — way to handle such a scenario is to replace the hard disk on the faulty node and
 just let RavenDB replicate the data back to the node. But if you don't have the data on another node, you might need to take additional steps. 
@@ -768,3 +766,11 @@ corrupted RavenDB database if the hard disk itself has suffered a failure.
 
 Even though we talked about disaster recovery, we haven't yet covered one crucial topic: the backup (and restore) of RavenDB. 
 This is because the backup process is an important topic on its own and deserves a proper forum for discussion. The next chapter is dedicated to backups, and even more important, to how to restore your systems afterward.
+
+[^1]: Simple Network Management Protocol
+[^2]: All these sizes, as well as the max size of database's growth are configurable, of course.
+[^3]: Full documentation for this feature can be found in the [OpenSSL Cookbook.](https://www.feistyduck.com/library/openssl-cookbook/online/ch-testing-with-openssl.html).
+[^4]: These are real internal and external IPs from one of our AWS machines.
+[^5]: By default the hash function used is XXHash64, which is non-cryptographic. It doesn't provide any level of authentication. A malicious user that can modify RavenDB's on disk files can update the data and the hash without RavenDB ever knowing. 
+When using an encrypted database, RavenDB uses cryptographic authentication to ensure that the data was modified only by someone who holds the secret encryption key.
+

--- a/Ch17/Ch17.md
+++ b/Ch17/Ch17.md
@@ -12,8 +12,7 @@ Let's consider each reason independently. Restoration after data loss can be nec
 wrong database, because the hard disk or the entire server died, etc. 
 I intentionally picked these two examples because they represent very different scenarios. In the latter case — a hardware failure
 resulting in the loss of a node — the other members in the cluster will just pick up the slack. You can set up a new node or 
-recover the old one and let the cluster fill in any missing details automatically.^[Remember that a single–node system cannot
-have any uptime SLA, since a single node failure will bring the whole thing down.]
+recover the old one and let the cluster fill in any missing details automatically.[^1]
 
 The case of accidental deletion of the database is more worrying. In this case, the database has been erased from all the nodes in the
 cluster. At this point, you can be saved by an offsite replica: a database to which you had set up external 
@@ -257,7 +256,7 @@ Now that we know how backups behave in RavenDB, let's go ahead and see how to co
 ### Setting up backups
 
 Backups in RavenDB are set up using the Studio by going to `Settings`, 
-`Manage Ongoing Tasks`, clicking on `Add Task` and selecting `Backup`.^[You can also set up backups through the API, of course.] You can see what the backup screen looks like in Figure 17.3.
+`Manage Ongoing Tasks`, clicking on `Add Task` and selecting `Backup`.[^2] You can see what the backup screen looks like in Figure 17.3.
 
 ![Defining a backup schedule for every Saturday at midnight](./Ch17/img03.png)
 
@@ -408,9 +407,7 @@ want to disable this flag if you're restoring to replace the database. Since thi
 > `e:\backups\users.northwind`, etc). 
 
 Figure 17.8 also shows some interesting options. If you are using a full backup option, you can specify that the new database 
-will be encrypted (and set up a new key).^[This option is not available for snapshots. A snapshot is a binary copy of the database
-at a given point in time. Either it is already encrypted and has its own key, or it is unencrypted and will require an import/export
-cycle for encryption.] Figure 17.9 shows the result of the restoration process.
+will be encrypted (and set up a new key).[^3] Figure 17.9 shows the result of the restoration process.
 
 ![Setting out to restore a database](./Ch17/img09.png)
 
@@ -556,8 +553,7 @@ When you restore from an encrypted snapshot, you _must_ provide the encryption k
 the restore process. The encryption key is not stored in the snapshot, and you must retrieve it from your own records.
 (When creating a new database with encryption, you are prompted to save the encryption key in a safe location.) 
 Once you provide the encryption key for the snapshot, the database will be restored normally and any incremental updates
-that happened after the snapshot was taken will also be encrypted and stored in the database.^[It's important to remember that while the snapshot itself is encrypted, the incremental updates made since the snapshot was
-taken are _not_ encrypted and are storing the data in plain text mode.]
+that happened after the snapshot was taken will also be encrypted and stored in the database.[^4]
 
 When restoring an unencrypted snapshot, you cannot provide an encryption key. You must first restore the snapshot and then export/import the data to a separate encrypted database. 
 
@@ -595,8 +591,7 @@ use the RavenDB Studio to restore a backup to a node and how to select the appro
 will restore. Remember, restoring a database from backup takes time and can impact operations; you should
 not rely on "let's restore from backup" as a failover strategy.
 
-Restoring a database is done on a single node, typically reading from local storage.^[You can also set up cloud storage
-mount volumes using external tools, which will be exposed to RavenDB as a local path.] After the database restore has 
+Restoring a database is done on a single node, typically reading from local storage.[^5] After the database restore has 
 completed, you can expand the database group to additional nodes in the cluster. It's also important that you remember to 
 disable ongoing tasks during restoration if you're restoring for a secondary purpose (such as checking the state of the 
 database at a particular point in time), rather than recovering from losing a database.
@@ -610,3 +605,12 @@ We concluded the chapter with a short discussion on restoring encrypted database
 in more depth in Chapter 14. Our next (and last) chapter is right around the corner, where we'll discuss operational
 recipes – specific scenarios you might run into in your day-to-day work maintaining RavenDB clusters – and how
 best to deal with them.
+
+[^1]: Remember that a single–node system cannot have any uptime SLA, since a single node failure will bring the whole thing down.
+[^2]: You can also set up backups through the API, of course.
+[^3]: This option is not available for snapshots. A snapshot is a binary copy of the database
+at a given point in time. Either it is already encrypted and has its own key, or it is unencrypted and will require an import/export
+cycle for encryption.
+[^4]: It's important to remember that while the snapshot itself is encrypted, the incremental updates made since the snapshot was
+taken are _not_ encrypted and are storing the data in plain text mode.
+[^5]: You can also set up cloud storage mount volumes using external tools, which will be exposed to RavenDB as a local path.

--- a/Ch18/Ch18.md
+++ b/Ch18/Ch18.md
@@ -612,7 +612,7 @@ sales across the entire chain with very little cost.
 #### Disconnect external replication/ETL from a remote source
 
 The bad thing about push-based ETL processes and replication is that sometimes, you want to disable them on 
-the destination side.[^1] That can be a bit awkward when you only have access to the destination and not the source.
+the destination side.[^2] That can be a bit awkward when you only have access to the destination and not the source.
 
 For example, you might want to disable the Jersey City shoe store from the aggregation process we outlined in the previous 
 section. That store has been sold and is no longer part of the chain, so you don't want its reports, but it'll take

--- a/Ch18/Ch18.md
+++ b/Ch18/Ch18.md
@@ -558,9 +558,7 @@ take the indexes export and import it on your production system.
 
 This will introduce the new indexes to production. RavenDB will start building them on the fly, replacing older indexes once the 
 indexing is done. You can monitor that process and wait until all the additional indexing activity has completed. Because your application
-isn't going to be using the new indexes, there will be very little impact while they are being built.^[Make sure that any changes to 
-the static indexes you make are backward compatible, otherwise queries may fail once the indexes complete and the side-by-side index
-is promoted to be the active index.] Once the indexes are done,
+isn't going to be using the new indexes, there will be very little impact while they are being built.[^1] Once the indexes are done,
 you can deploy your new version to production knowing that you already taught the database what to expect.
 
 #### Daisy-chaining data
@@ -614,8 +612,7 @@ sales across the entire chain with very little cost.
 #### Disconnect external replication/ETL from a remote source
 
 The bad thing about push-based ETL processes and replication is that sometimes, you want to disable them on 
-the destination side.^[Push-based in this context refers to the fact that they
-are defined in the source and they push the data to the destination.] That can be a bit awkward when you only have access to the destination and not the source.
+the destination side.[^1] That can be a bit awkward when you only have access to the destination and not the source.
 
 For example, you might want to disable the Jersey City shoe store from the aggregation process we outlined in the previous 
 section. That store has been sold and is no longer part of the chain, so you don't want its reports, but it'll take
@@ -665,3 +662,7 @@ We finished the chapter with an interesting challenge: distributed aggregation o
 locations using several distinct features in tandem. This kind of usage is pretty common. One of the 
 strengths of RavenDB is its ability to treat features in an orthogonal manner; you can mix, match and combine them to 
 get to some really nice results. 
+
+[^1]: Make sure that any changes to the static indexes you make are backward compatible, otherwise queries may fail once the indexes complete and the side-by-side index
+is promoted to be the active index.
+[^2]: Push-based in this context refers to the fact that they are defined in the source and they push the data to the destination.

--- a/Intro/Intro.md
+++ b/Intro/Intro.md
@@ -51,13 +51,12 @@ people also seem to like reading them.
 
 I'm a developer at heart. That means that one of my favorite activities is writing code. Writing documentation, on
 the other hand, is so far down the list of my favorite activities that one could say it isn't even on the list. I
-do like writing blog posts, and I've been maintaining an [active blog](http://ayende.com/blog) for close to fifteen years.^[You can find it at http://ayende.com/blog]
+do like writing blog posts, and I've been maintaining an [active blog](http://ayende.com/blog) for close to fifteen years.[^1]
 
 ### About this book
 
 What you're reading now is effectively a book-length blog post. The main idea here is that I want to give you a way to
-_grok_ RavenDB.^[Grok means "to understand so thoroughly that the observer becomes a part of the observed — to merge, blend, 
-intermarry, lose identity in group experience." From Robert A. Heinlein, _Stranger in a Strange Land_.] This 
+_grok_ RavenDB.[^2] This 
 means not only gaining knowledge of what RavenDB does, but also all the reasoning behind the bytes. In effect, I want
 you to understand all the _whys_ of RavenDB.
 
@@ -305,3 +304,7 @@ In many cases, I have elected to discuss a feature, give one or two examples of 
 
 This book is meant to be more than API listing. It is meant to tell a story, the story of how you can make the best use of 
 RavenDB in your applications and environment. So, without further ado, turn the page and let's get started.
+
+[^1]: You can find it at http://ayende.com/blog
+[^2]: Grok means "to understand so thoroughly that the observer becomes a part of the observed — to merge, blend, 
+intermarry, lose identity in group experience." From Robert A. Heinlein, _Stranger in a Strange Land_.


### PR DESCRIPTION
To generate HTML and display a book chapter on ravendb.net webiste a popular Markdig library is made use of to process documents in ravendb/book repository.
Markdig is a fast, CommonMark compliant Markdown processor for .NET. Unfortunately, not all syntax used in the book repository appears to be understood by the Markdig parser. This is particulary the case with footnotes. That is why I suggest altering the way the footnotes are represented. The change strictly follows the Markdig and CommonMark specs in that respect. Furthermore, the new footnote syntax has been tested by means of the script available in the book repository. It turns out that the pdf file generated by the script is not affected at all by the change. The output stays the same and the Pandoc parser does not seem to notice 
the difference between the current and previous version, which is a desirable outcome in this situation. The rest of the text remains unchanged although some other elements (e.g. image captions or listing headers) also don't appear to be compliant with CommonMark, yet finally I decided to deal with that programatically.