### PR TITLE
[ravendb/book] Remove unused line

### DIFF
--- a/Ch09/Ch09.md
+++ b/Ch09/Ch09.md
@@ -1,8 +1,6 @@
 ﻿
 ## Querying in RavenDB
 
-[Querying in RavenDB]:(#query-engine)
-
 Queries in RavenDB use a SQL-like language called "RavenDB Query Language,"[^1] henceforth known as RQL.[^2]
 
 You've already run into the RavenDB Query Language when using subscriptions, even if I didn't explicitly call it out as such. Both


### PR DESCRIPTION
Could we please remove the line? Firstly, it is present in none of the available book versions, including paperback.  Secondly, our CommonMark compliant html renderer usues it to create a paragraph which contains some garbage and forces us to write extra code to exclude it from the view.  

![cha9](https://user-images.githubusercontent.com/52409106/65021022-9a2eeb80-d92e-11e9-9e0f-d37a997d0851.jpg)


