### PR TITLE
[book] HRMarketing-364 Remove whitespace

### DIFF
--- a/Ch03/Ch03.md
+++ b/Ch03/Ch03.md
@@ -996,7 +996,7 @@ get to running clusters of RavenDB and understanding how the distributed portion
 
 [^1]: This ended up being sorted out eventually by uttering the magic words: "computer error." 
 But it was very exciting for a while there.
-[^2]: The [book]( https://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215) is a bit dry, but I remember 
+[^2]: The [book](https://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215) is a bit dry, but I remember 
 being very impressed when I read it the first time.
 [^3]: Circle the appropriate choice.
 [^4]: Except maybe which rabbit hole she wandered down...


### PR DESCRIPTION
We need to add rel="nofollow" attribute in all outbound links for the SEO purposes (https://issues.hibernatingrhinos.com/issue/HRMarketing-364).  Our book parser fails to process the link due to the whitespace character present in the markdown code.    