### PR TITLE
HRINT-3120 Chapter 4: Add a bullet about the streamed query data

### DIFF
--- a/Ch04/Ch04.md
+++ b/Ch04/Ch04.md
@@ -882,6 +882,9 @@ The use of streaming queries requires you to keep a few things in mind:
   for the session and eventually end up with a truly humongous batch to send to the server. Typically, if you want to read a lot of results and modify them, you'll
   use a stream and a `Bulk Insert` at the same time. You'll read from the stream and call `Store` on the bulk insert for each. This way, you'll have both streaming
   for the query as you read and streaming via the bulk insert on the write. 
+  
+* The stream results are a snapshot of the data at the time when the query is computed by the server. 
+  Results that match the query after it was already processed are not streamed to the client.
 
 When you need to select whether to use a regular (batched) query or a streaming query, consider the number of items that you expect to get from the query and
 what you intend to do with them. If the number is small, you'll likely want to use a query for its simple API. If you need to process many results, you 


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/HRINT-3120/Chapter-4-Add-bullet-to-explain-that-streamed-query-data-is-frozen

@ayende
I hope this is correct & acceptable to write 
I realized this when working on the streaming query documentation. (https://github.com/ravendb/docs/pull/1740)